### PR TITLE
Set default value for head_tolerance

### DIFF
--- a/src/core/swmm/options/dynamic_wave.py
+++ b/src/core/swmm/options/dynamic_wave.py
@@ -80,7 +80,7 @@ class DynamicWave(Section):
         ## Difference in computed head at each node between successive trials below
         ## which the flow solution for the current time step is assumed to have converged.
         ## The default tolerance is 0.005 ft (0.0015 m).
-        self.head_tolerance = ''
+        self.head_tolerance = '0.005'
 
         ## Smallest time step allowed when variable time steps are used for dynamic
         ## wave flow routing. The default value is 0.5 seconds.


### PR DESCRIPTION
Would close #129.  Without a default value, ```section.head_tolerance = float(self.txtTolerance.text())``` fails because ```u''``` can't be converted to a float.  Setting the default value to 0.005 ft, consistent with the SWMM User's Manual, will allow the dialog box to close.  However, it does not take into account that the project could be in metric units.  