### PR TITLE
Fix issue where patterns, curves, or time series can be clipped

### DIFF
--- a/src/ui/EPANET/frmPatternEditor.py
+++ b/src/ui/EPANET/frmPatternEditor.py
@@ -29,6 +29,7 @@ class frmPatternEditor(QtGui.QMainWindow, Ui_frmPatternEditor):
             pattern = self.section.value[pattern]
         if isinstance(pattern, Pattern):
             self.editing_item = pattern
+            self.tblMult.setColumnCount(max(len(pattern.multipliers) + 1, self.tblMult.columnCount()))
         self.txtPatternID.setText(str(pattern.name))
         self.txtDescription.setText(str(pattern.description))
         point_count = -1

--- a/src/ui/SWMM/frmCurveEditor.py
+++ b/src/ui/SWMM/frmCurveEditor.py
@@ -40,6 +40,7 @@ class frmCurveEditor(QtGui.QMainWindow, Ui_frmCurveEditor):
             curve = self.section.value[curve]
         if isinstance(curve, Curve):
             self.editing_item = curve
+            self.tblMult.setRowCount(max(len(curve.curve_xy) + 1, self.tblMult.rowCount()))
         if self.curve_type == "CONTROL":
             self.cboCurveType.setVisible(False)
             self.lblCurveType.setVisible(False)

--- a/src/ui/SWMM/frmTimeseries.py
+++ b/src/ui/SWMM/frmTimeseries.py
@@ -39,6 +39,7 @@ class frmTimeseries(QtGui.QMainWindow, Ui_frmTimeseries):
             self.editing_item = timeseries
             self.txtTimeseriesName.setText(timeseries.name)
             self.txtDescription.setText(timeseries.comment)
+            self.tblTime.setRowCount(max(len(timeseries.values) + 1, self.tblTime.rowCount()))
             if timeseries.file:
                 if len(timeseries.file) > 0:
                     self.rbnExternal.setChecked(True)


### PR DESCRIPTION
Partially address issues #125, #135, and #241.

The row or column count was hard-coded in the designed form, so if you had an existing inp file with more entries than the hard-coded number, it would be clipped when the form was opened.

I will check those issues to make sure it is clear what still needs to be addressed.