### PR TITLE
Make default infiltration model and default conduit geometry change when the user clicks OK

### DIFF
--- a/src/ui/SWMM/frmDefaultsEditor.py
+++ b/src/ui/SWMM/frmDefaultsEditor.py
@@ -247,7 +247,7 @@ class frmDefaultsEditor(QMainWindow, Ui_frmGenericDefaultsEditor):
 
     def eventFilter(self, ui_object, event):
         if event.type() == QtCore.QEvent.WindowUnblocked:
-            if self.refresh_column and self.refresh_column > -1:
+            if self.refresh_column is not None and self.refresh_column > -1:
                 self.set_infilmodel_cell(self.refresh_column)
                 self.set_channel_cell(self.refresh_column)
                 self.refresh_column = -1


### PR DESCRIPTION
Closes #337 

Check if self.refresh_column is not None
if the default model has changed, self.refresh_column = 0
if 0: evaluates to False, so check if is not None instead