### PR TITLE
Change check for finding item so each link_group is checked for a match

### DIFF
--- a/src/core/project_base.py
+++ b/src/core/project_base.py
@@ -73,10 +73,11 @@ class ProjectBase(object):
     def find_link(self, link_name):
         for link_group in self.links_groups():
             if link_group and link_group.value:
-                try:
-                    return link_group.find_item(link_name)
-                except:
-                    return None
+                possible_match = link_group.find_item(link_name)
+                if possible_match:
+                    return possible_match
+
+        return None
 
     def all_vertices(self, set_names=False):
         """ Return a list of Coordinate objects, one for each internal vertices of all links.


### PR DESCRIPTION
Closes #343 

I think this prevents the function from returning `None` if `link_name` is not found in the first group, and instead keep iterating through the remaining `self.link_groups()` to look for a match.

My test with pressure_main.inp was successful and searching the code makes it look like this function is only called from frmProfilePlot.py.  