### PR TITLE
Only set selected item if items exist

### DIFF
--- a/src/ui/SWMM/frmStatisticsReportSelection.py
+++ b/src/ui/SWMM/frmStatisticsReportSelection.py
@@ -43,7 +43,8 @@ class frmStatisticsReportSelection(QMainWindow, Ui_frmStatisticsReportSelection)
         if newIndex != 3:
             for item in self.output.all_items[newIndex]:
                 self.lstName.addItem(item)
-            self.lstName.item(0).setSelected(True)
+            if self.output.all_items[newIndex]:
+                self.lstName.item(0).setSelected(True)
             self.cboVariable.clear()
             for attribute in object_type.attributes:
                 self.cboVariable.addItem(attribute.name)


### PR DESCRIPTION
Towards #345 

With this change the UI still lets a user click "OK" if they haven't selected any non-existent subcatchments, which causes the UI to crash.  So maybe we need another commit that addresses that or we can do a follow-up PR.