### PR TITLE
Save project to prevent blank file

### DIFF
--- a/src/ui/SWMM/frmMainSWMM.py
+++ b/src/ui/SWMM/frmMainSWMM.py
@@ -1458,6 +1458,7 @@ class frmMainSWMM(frmMain):
                 filename, file_extension = os.path.splitext(self.project.file_name)
                 self.run_inp_file = mkstemp(prefix=filename + '_', suffix='.inp', text=True)
                 self.project.file_name_temporary = self.run_inp_file[1]
+                self.save_project(self.project.file_name_temporary)
             else:
                 return None
         else:


### PR DESCRIPTION
Closes #350 

in `if use_existing` the function `self.save_project(self.project.file_name_temporary)` is called.  I think we need to call that function in the `elif` as well, to prevent the file from being blank.