### PR TITLE
Disable uniform item size for conduit types

### DIFF
--- a/src/ui/SWMM/frmCrossSection.py
+++ b/src/ui/SWMM/frmCrossSection.py
@@ -289,6 +289,8 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
         self.listWidget.item(23).setIcon(QtGui.QIcon("./swmmimages/24custom.png"))
         self.listWidget.item(24).setIcon(QtGui.QIcon("./swmmimages/25na.png"))
 
+        self.listWidget.setUniformItemSizes(False)
+
         self.listWidget_currentItemChanged()
 
 


### PR DESCRIPTION
Disable uniform item size so text describing conduit types is fully displayed

This addresses the first part of #311.  With this change you can see the full text describing each conduit type:
![image](https://user-images.githubusercontent.com/13906772/73501649-68696f00-437b-11ea-8308-b7200528d3aa.png)
