### PR TITLE
Calculate decimal days rather than int days

### DIFF
--- a/src/ui/SWMM/frmRunSWMM.py
+++ b/src/ui/SWMM/frmRunSWMM.py
@@ -4,7 +4,7 @@ import PyQt5.QtGui as QtGui
 import PyQt5.QtCore as QtCore
 from PyQt5.QtWidgets import QMessageBox
 import Externals.swmm.model.swmm5 as pyswmm
-from datetime import datetime
+from datetime import datetime, timedelta
 from ui.frmRunSimulation import frmRunSimulation, RunStatus
 from ui.model_utility import process_events
 
@@ -212,7 +212,9 @@ class frmRunSWMM(frmRunSimulation):
                                          self._main_form.project.options.dates.end_time, "%m/%d/%Y %H:%M:%S")
             start_date = datetime.strptime(self._main_form.project.options.dates.start_date + ' ' +
                                            self._main_form.project.options.dates.start_time, "%m/%d/%Y %H:%M:%S")
-            return (end_date - start_date).days
+            time_difference = (end_date - start_date)
+            days = time_difference.total_seconds() / timedelta(days=1).total_seconds()
+            return days
         except:
             return 0.0
 

--- a/src/ui/SWMM/frmRunSWMM.py
+++ b/src/ui/SWMM/frmRunSWMM.py
@@ -138,7 +138,7 @@ class frmRunSWMM(frmRunSimulation):
                         date_now = datetime.now()
                         if (date_now - date_updated).microseconds > 100000:
                             self.update_progress_days(elapsed_days, total_days)
-                            self.update_progress_bar(round(elapsed_days), total_days)
+                            self.update_progress_bar(elapsed_days, total_days)
                             process_events()
                             date_updated = date_now
                 else:


### PR DESCRIPTION
Closes #349 

The inp file in #349 has a simulation time of 10 hours but a routing step of 0.01 seconds, so it runs for a non-trivial amount of time (it took about 11 minutes on my computer).  The function `compute_total_days` was returning days as 0 for this file.  

Then in frmRunSWMM.py, the program checks `if total_days`, but if total_days = 0, then that evaluates to False, so the progress bar is not set to visible in that case, which makes it so the user can't see the progress of the simulation or click on the buttons.

This change returns the day as a decimal so the progress bar will get set up properly even in cases where the simulation is less than one day.  I've tested it with long and short files and it seems to work properly but let me know if I missed something!