### PR TITLE
Save widget geometry and shape for Title/Notes

### DIFF
--- a/src/ui/SWMM/frmTitle.py
+++ b/src/ui/SWMM/frmTitle.py
@@ -13,7 +13,6 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         self.cmdCancel.clicked.connect(self.cmdCancel_Clicked)
         self.set_from(main_form.project)
         self._main_form = main_form
-        self.show_widget_values()
 
     def set_from(self, project):
         self.txtTitle.setPlainText(project.title.title)
@@ -23,19 +22,7 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         if section.title != self.txtTitle.toPlainText():
             self._main_form.mark_project_as_unsaved()
         section.title = self.txtTitle.toPlainText()
-        self.save_widget_values()
         self.close()
 
     def cmdCancel_Clicked(self):
-        self.save_widget_values()
         self.close()
-
-    def save_widget_values(self):
-        qsettings = QtCore.QSettings()
-        qsettings.setValue("geometry", self.saveGeometry())
-        qsettings.setValue("windowState", self.saveState())
-
-    def show_widget_values(self):
-        qsettings = QtCore.QSettings()
-        self.restoreGeometry(qsettings.value("geometry", self.saveGeometry(), type=QtCore.QByteArray))
-        self.restoreState(qsettings.value("windowState", self.windowState(), type=QtCore.QByteArray))

--- a/src/ui/SWMM/frmTitle.py
+++ b/src/ui/SWMM/frmTitle.py
@@ -13,6 +13,7 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         self.cmdCancel.clicked.connect(self.cmdCancel_Clicked)
         self.set_from(main_form.project)
         self._main_form = main_form
+        self.show_widget_values()
 
     def set_from(self, project):
         self.txtTitle.setPlainText(project.title.title)
@@ -22,7 +23,19 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         if section.title != self.txtTitle.toPlainText():
             self._main_form.mark_project_as_unsaved()
         section.title = self.txtTitle.toPlainText()
+        self.save_widget_values()
         self.close()
 
     def cmdCancel_Clicked(self):
+        self.save_widget_values()
         self.close()
+
+    def save_widget_values(self):
+        qsettings = QtCore.QSettings()
+        qsettings.setValue("geometry", self.saveGeometry())
+        qsettings.setValue("windowState", self.saveState())
+
+    def show_widget_values(self):
+        qsettings = QtCore.QSettings()
+        self.restoreGeometry(qsettings.value("geometry", self.saveGeometry(), type=QtCore.QByteArray))
+        self.restoreState(qsettings.value("windowState", self.windowState(), type=QtCore.QByteArray))

--- a/src/ui/SWMM/frmTitle.py
+++ b/src/ui/SWMM/frmTitle.py
@@ -13,6 +13,8 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         self.cmdCancel.clicked.connect(self.cmdCancel_Clicked)
         self.set_from(main_form.project)
         self._main_form = main_form
+        self.restoreGeometry(self._main_form.program_settings.value("Geometry/" + "frmTitle_geometry", self.saveGeometry(), type=QtCore.QByteArray))
+        self.restoreState(self._main_form.program_settings.value("Geometry/" + "frmTitle_state", self.windowState(), type=QtCore.QByteArray))
 
     def set_from(self, project):
         self.txtTitle.setPlainText(project.title.title)
@@ -22,7 +24,11 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         if section.title != self.txtTitle.toPlainText():
             self._main_form.mark_project_as_unsaved()
         section.title = self.txtTitle.toPlainText()
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_state", self.saveState())
         self.close()


### PR DESCRIPTION
See #361 

This demonstrates a possible way to save and restore the widget dimensions for the Title/Notes box.

I'm not sure if this is the best approach, so before going through the rest of the widgets and adding code, I'm hoping to get feedback.  If so, I would add these functions and call them like I do in this example in the other SWMM widgets.  