### PR TITLE
Use integer division

### DIFF
--- a/src/ui/SWMM/frmStatisticsReport.py
+++ b/src/ui/SWMM/frmStatisticsReport.py
@@ -337,7 +337,7 @@ class frmStatisticsReport(QMainWindow, Ui_frmStatisticsReport):
                                 dpi=100)
         N = len(self.statsResult.EventList)
         if N > 0:
-            M = int(N) / 50
+            M = N // 50
             if M == 0:
                 M = 1
             lX = []


### PR DESCRIPTION
Closes #366 

This line corresponds to "M := N div 50;" in the old GUI
In pascal N div 50 returns the integer part of the result
of dividing the integers, so use integer division here


I think this worked with python 2 because / meant integer division but in python 3 it does not