### PR TITLE
Fix IRREGULAR xsections

### DIFF
--- a/src/core/swmm/inp_reader_sections.py
+++ b/src/core/swmm/inp_reader_sections.py
@@ -824,9 +824,6 @@ class CrossSectionReader(SectionReader):
                     cross_section.barrels = fields[6]
         elif cross_section.shape == CrossSectionShape.NotSet:
             return None
-        # elif cross_section.shape == CrossSectionShape.IRREGULAR:
-        #     if len(fields) > 2:
-        #         cross_section.transect = fields[2]
         else:
             if len(fields) > 2:
                 cross_section.geometry1 = fields[2]

--- a/src/core/swmm/inp_writer_sections.py
+++ b/src/core/swmm/inp_writer_sections.py
@@ -593,7 +593,6 @@ class CrossSectionWriter(SectionWriter):
 
     field_format_shape =     "{:16}\t{:12}\t{:16}\t{:10}\t{:10}\t{:10}\t{:10}\t{:10}"
     field_format_custom =    "{:16}\t{:12}\t{:16}\t{:10}\t{:10}\t{:10}\t{:10}"
-    # field_format_irregular = "{:16}\t{:12}\t{:16}"
 
     @staticmethod
     def as_text(cross_section):
@@ -607,8 +606,6 @@ class CrossSectionWriter(SectionWriter):
             g3 = '0'
             g4 = '0'
             inp += CrossSectionWriter.field_format_custom.format(cross_section.link, shape_name, cross_section.geometry1, cross_section.curve, g3, g4, cross_section.barrels)
-        # elif cross_section.shape == CrossSectionShape.IRREGULAR:
-        #     inp += CrossSectionWriter.field_format_irregular.format(cross_section.link, cross_section.shape.name, cross_section.transect)
         else:
             g1 = str(cross_section.geometry1)
             g2 = str(cross_section.geometry2)

--- a/src/ui/SWMM/frmCrossSection.py
+++ b/src/ui/SWMM/frmCrossSection.py
@@ -178,7 +178,7 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
                 if value.shape.name == 'IRREGULAR':
                     # for irregular, combo needs transect names, dialog opens transect buttons
                     for index in range(0,self.cboCombo.count()):
-                        if value.transect == self.cboCombo.itemText(index):
+                        if value.geometry1 == self.cboCombo.itemText(index):
                             self.cboCombo.setCurrentIndex(index)
 
                 if value.shape.name == 'CUSTOM':
@@ -247,7 +247,7 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
         if value.shape.name == 'IRREGULAR':
             # for irregular, combo needs transect names, dialog opens transect buttons
             for index in range(0,self.cboCombo.count()):
-                if value.transect == self.cboCombo.itemText(index):
+                if value.geometry1 == self.cboCombo.itemText(index):
                     self.cboCombo.setCurrentIndex(index)
 
         if value.shape.name == 'CUSTOM':
@@ -333,7 +333,6 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
         value.geometry2 = self.txt2.text()
         value.geometry3 = self.txt3.text()
         value.geometry4 = self.txt4.text()
-        value.transect = ''
         value.curve = ''
         XType = ''
         if current_selection == 'Rectangular':
@@ -349,7 +348,6 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
             XType = 'POWER'
         elif current_selection == 'Irregular':
             XType = 'IRREGULAR'
-            value.transect = self.cboCombo.itemText(self.cboCombo.currentIndex())
         elif current_selection == 'Circular':
             XType = 'CIRCULAR'
         elif current_selection == 'Force Main':


### PR DESCRIPTION
Closes #388 

The UI stores the name of an IRREGULAR xsection in `geometry1`.  This PR keeps that behavior and makes the UI go through the `geometry1` values rather than the `transect` values, which are blank.  It also removes old and commented-out code that may have corresponded to storing the name in `transect` rather than `geometry1`.