### PR TITLE
External precipitation files

### DIFF
--- a/src/core/swmm/inp_writer_sections.py
+++ b/src/core/swmm/inp_writer_sections.py
@@ -69,6 +69,7 @@ from core.swmm.hydrology.subcatchment import InitialLoading
 from core.swmm.hydrology.subcatchment import InitialLoadings
 from core.swmm.hydrology.unithydrograph import UnitHydrographEntry
 from core.swmm.hydrology.unithydrograph import UnitHydrograph
+from core.swmm.hydrology.raingage import RainDataSource
 from core.swmm.options.backdrop import BackdropOptions
 from core.swmm.options.general import FlowUnits
 from core.swmm.options.general import FlowRouting
@@ -1215,7 +1216,7 @@ class RainGageWriter(SectionWriter):
                 rain_gage.rain_format.name,
                 rain_gage.rain_interval,
                 rain_gage.snow_catch_factor)
-        if rain_gage.timeseries != "None":
+        if rain_gage.data_source is RainDataSource.TIMESERIES:
             inp += "{:10}\t{}".format("TIMESERIES", rain_gage.timeseries)
         else:
             inp += '{:10}\t{}\t{:10}\t{:5}'.format(

--- a/test/core/swmm/test_raingages.py
+++ b/test/core/swmm/test_raingages.py
@@ -10,6 +10,7 @@ class SimpleRainGageTest(unittest.TestCase):
     """Test RAINGAGES section"""
 
     TEST_TEXTS = ["RainGage         INTENSITY 0:05   1.0    TIMESERIES 2-yr "]
+    TEST_FILE_TEXTS = ['Logan            VOLUME    1:00     1        FILE       "190770BostonNCDC.dat" *          IN   ']
     SOURCE_TEXTS =["""[RAINGAGES]
 ;;               Rain      Time   Snow   Data
 ;;Name           Type      Intrvl Catch  Source
@@ -24,6 +25,14 @@ RainGage         INTENSITY 0:05   1.0    TIMESERIES 2-yr"""]
     def test_one_raingage(self):
         """Test one rain gage"""
         for test_text in self.TEST_TEXTS:
+            my_options = RainGageReader.read(test_text)
+            actual_text = RainGageWriter.as_text(my_options)
+            msg = '\nSet:'+test_text+'\nGet:'+actual_text
+            self.assertTrue(match(actual_text, test_text), msg)
+
+    def test_file_raingage(self):
+        """Test FILE raingage"""
+        for test_text in self.TEST_FILE_TEXTS:
             my_options = RainGageReader.read(test_text)
             actual_text = RainGageWriter.as_text(my_options)
             msg = '\nSet:'+test_text+'\nGet:'+actual_text


### PR DESCRIPTION
Closes #390 

If you open the rain gage editor and no timeseries are defined for your project, `rain_gage.timeseries` will equal `'*'` rather than `'None'`, so check the RainDataSource instead