### PR TITLE
SWMM Type1 and Type2 pump plots

### DIFF
--- a/src/ui/SWMM/frmCurveEditor.py
+++ b/src/ui/SWMM/frmCurveEditor.py
@@ -1,4 +1,3 @@
-import PyQt5.QtGui as QtGui
 import PyQt5.QtCore as QtCore
 from PyQt5.QtWidgets import QMainWindow, QLineEdit, QTableWidgetItem
 from PyQt5.QtWidgets import QMessageBox, QFileDialog
@@ -7,13 +6,10 @@ from ui.help import HelpHandler
 import core.swmm.curves
 from ui.SWMM.frmCurveEditorDesigner import Ui_frmCurveEditor
 import ui.convenience
-from core.swmm.curves import CurveType
 from core.swmm.curves import Curve
-# from PyQt5.QtGui import *
 from ui.model_utility import ParseData
 import os
 import traceback
-import numpy as np
 import pandas as pd
 from ui.frmPlotViewer import frmPlotViewer
 

--- a/src/ui/SWMM/frmCurveEditor.py
+++ b/src/ui/SWMM/frmCurveEditor.py
@@ -315,8 +315,15 @@ class frmCurveEditor(QMainWindow, Ui_frmCurveEditor):
         if n > 0:
             ds = pd.Series(self.Y, index=self.X)
             df = pd.DataFrame({'DS-':ds})
-            frm_plt = frmPlotViewer(df,'xy',self.curve_type + ' Curve ' + self.txtCurveName.text(), self.windowIcon(),
-                                    self.tblMult.horizontalHeaderItem(0).text(), self.tblMult.horizontalHeaderItem(1).text())
+            # if Pump Type1 or Type2, plot as step function
+            if self.curve_type == 'PUMP' and self.cboCurveType.currentIndex() in (0, 1):
+                frm_plt = frmPlotViewer(df, 'step', self.curve_type + ' Curve ' + self.txtCurveName.text(),
+                                        self.windowIcon(), self.tblMult.horizontalHeaderItem(0).text(),
+                                        self.tblMult.horizontalHeaderItem(1).text())
+            else:
+                frm_plt = frmPlotViewer(df, 'xy', self.curve_type + ' Curve ' + self.txtCurveName.text(),
+                                        self.windowIcon(), self.tblMult.horizontalHeaderItem(0).text(),
+                                        self.tblMult.horizontalHeaderItem(1).text())
             frm_plt.setWindowTitle('Curve Viewer')
             frm_plt.setWindowModality(QtCore.Qt.ApplicationModal)
             frm_plt.show()

--- a/src/ui/frmPlotViewer.py
+++ b/src/ui/frmPlotViewer.py
@@ -1,13 +1,9 @@
-from PyQt5 import QtCore, QtGui
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import QMainWindow, QVBoxLayout
 from ui.help import HelpHandler
 from .frmPlotViewerDesigner import Ui_frmPlot
 import matplotlib.dates as mdates
-from .model_utility import ParseData
 from .model_utility import BasePlot
-import numpy as np
-from datetime import datetime
 
 
 class frmPlotViewer(QMainWindow, Ui_frmPlot):

--- a/src/ui/frmPlotViewer.py
+++ b/src/ui/frmPlotViewer.py
@@ -46,6 +46,9 @@ class frmPlotViewer(QMainWindow, Ui_frmPlot):
         elif plot_type == 'xy':
             self.plot_type = 'xy'
             self.help_topic = "swmm/src/src/transecteditordialog.htm"
+        elif plot_type == 'step':
+            self.plot_type = 'step'
+            self.help_topic = ''   # TODO
         self.plot = CurvePlot(self.fraPlot, width=6, height=2, dpi=100)
         layout = QVBoxLayout(self.fraPlot)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -98,6 +101,8 @@ class frmPlotViewer(QMainWindow, Ui_frmPlot):
                 self.plot.set_time_series_data(self.dataset)
             elif self.plot_type == 'xy':
                 self.plot.set_xy_data(self.dataset, self.x_title, self.y_title)
+            elif self.plot_type == 'step':
+                self.plot.set_xy_data(self.dataset, self.x_title, self.y_title, step=True)
 
         pass
 
@@ -119,15 +124,18 @@ class CurvePlot(BasePlot):
         self.line, = self.axes.plot([],[], 'r-')
         pass
 
-    def setData(self, X, Y, Xlabel, Ylabel):
-        color = self.get_colors()
-        #self.axes.scatter(self.X, self.Y, s=10, c=color, marker="o", label="")
-        #self.axes.legend(loc='upper left')
-        self.line.set_xdata(X)
-        self.line.set_ydata(Y)
-        self.line.set_marker("o")
-        self.line.set_markeredgecolor("blue")
-        self.line.set_markerfacecolor("lightblue")
+    def setData(self, X, Y, Xlabel, Ylabel, step=False):
+        if step:
+            self.line = self.axes.step(X, Y, 'r-')
+            self.axes.scatter(X, Y, marker='o', color='lightblue', edgecolor='blue')
+            self.axes.scatter(X[0:-1], Y[1:], marker='o', color='lightblue', edgecolor='blue')
+
+        else:
+            self.line.set_xdata(X)
+            self.line.set_ydata(Y)
+            self.line.set_marker("o")
+            self.line.set_markeredgecolor("blue")
+            self.line.set_markerfacecolor("lightblue")
 
         self.setXlabel(Xlabel)
         self.setYlabel(Ylabel)
@@ -135,7 +143,7 @@ class CurvePlot(BasePlot):
         self.axes.autoscale_view()
         self.fig.canvas.draw()
         self.fig.canvas.flush_events()
-        #self.setTitle('Pump head curve for %s' % aData.name)
+
         pass
 
     def set_time_series_data(self, df):
@@ -163,14 +171,14 @@ class CurvePlot(BasePlot):
             self.fig.canvas.draw()
             self.fig.canvas.flush_events()
 
-    def set_xy_data(self, df, x_title, y_title):
+    def set_xy_data(self, df, x_title, y_title, step=False):
         if df.shape[0] > 0 and df.shape[1] > 0:
             x = []
             y = []
             for row in range(len(df)):
                 x.append(float(df.index[row]))
                 y.append(float(df.iloc[row][0]))
-            self.setData(x, y, x_title, y_title)
+            self.setData(x, y, x_title, y_title, step)
 
             self.fig.canvas.draw()
             self.fig.canvas.flush_events()


### PR DESCRIPTION
Closes #397 

- Add an optional argument `step` (with default value `False`) to function `setData`
- Set `step` to `True` if curve is PUMP and is Type1 or Type2
- Make those plots look like step functions with dots
![image](https://user-images.githubusercontent.com/13906772/75295677-18e25b80-57e0-11ea-89ec-71620899e031.png)

- Remove some commented out code and some unused imports

I wasn't sure what to set for the help dialog on the plot viewer for step plots.  Clicking on the plot viewer's help for xy data did not seem to launch any dialog.  The Delphi GUI has a help button on the curve editor but not on the plot dialog.  So maybe the help on the plot dialog should be removed.  I left it empty for now and marked it with #TODO.

I think this has to be tested in Run mode rather than Debug.