### PR TITLE
Make ground elevation in profile green, linearly interpolated

### DIFF
--- a/src/ui/SWMM/frmProfilePlot.py
+++ b/src/ui/SWMM/frmProfilePlot.py
@@ -376,9 +376,9 @@ class frmProfilePlot(QMainWindow, Ui_frmProfilePlot):
 
 
         # GROUND LEVEL PLOT
-        func = interp1d(pltxspans,Groundspans,kind='cubic')
-        xinterp = np.linspace(min(pltxspans),max(pltxspans),300)
-        plt.plot(xinterp,func(xinterp), ':k')
+        func = interp1d(pltxspans, Groundspans, kind='linear')
+        xinterp = np.linspace(min(pltxspans), max(pltxspans), 300)
+        plt.plot(xinterp, func(xinterp), 'g')
 
         if len(LKsToPlotAppendix)>0:
             for ind,val in enumerate(MHListAppendix):


### PR DESCRIPTION
There are lots of small pieces to address with the profile plot and trying to fix them all at once was not working for me.  I am going to submit PRs with incremental fixes.  

In #365 you see the ground elevation as a dotted black line with cubic interpolation between the points.  This PR makes the ground green and linearly interpolated.  Here is what it looks like for Example1.inp, Node 19 -> 17

New UI:
![image](https://user-images.githubusercontent.com/13906772/75298374-2b13c800-57e7-11ea-9a1b-6997f7fdbbf0.png)

Compare to the Delphi UI (note the x axis has 1500 on the left hand side and 0 on the right hand side):
![image](https://user-images.githubusercontent.com/13906772/75298389-34049980-57e7-11ea-8878-2cb75f5e5a24.png)
