### PR TITLE
Remember geometry and state for SWMM frms

### DIFF
--- a/src/ui/SWMM/frmAbout.py
+++ b/src/ui/SWMM/frmAbout.py
@@ -12,5 +12,14 @@ class frmAbout(QMainWindow, Ui_frmAbout):
         self.cmdOK.clicked.connect(self.cmdOK_Clicked)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmAbout_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmAbout_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmAbout_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmAbout_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmAbout_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmAbout_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmAquifers.py
+++ b/src/ui/SWMM/frmAquifers.py
@@ -63,6 +63,4 @@ class frmAquifers(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmAquifers_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmAquifers_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmAquifers.py
+++ b/src/ui/SWMM/frmAquifers.py
@@ -48,9 +48,21 @@ class frmAquifers(frmGenericPropertyEditor):
             combobox.setCurrentIndex(selected_index)
             self.tblGeneric.setCellWidget(13, column, combobox)
 
+        self._main_form = main_form
+        if (main_form.program_settings.value("Geometry/" + "frmAquifers_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmAquifers_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmAquifers_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmAquifers_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
+        self._main_form.program_settings.setValue("Geometry/" + "frmAquifers_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmAquifers_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmAquifers_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmAquifers_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmCalibrationData.py
+++ b/src/ui/SWMM/frmCalibrationData.py
@@ -82,6 +82,13 @@ class frmCalibrationData(QMainWindow, Ui_frmCalibrationData):
 
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmCalibrationData_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmCalibrationData_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmCalibrationData_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmCalibrationData_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def toolButton_Clicked(self):
         file_name, ftype = QFileDialog.getOpenFileName(self, "Select a Calibration File", '',
                                                       "Data files (*.DAT);;All files (*.*)")
@@ -187,7 +194,11 @@ class frmCalibrationData(QMainWindow, Ui_frmCalibrationData):
                 self.defaults.config.setValue("Calibration/File12", '')
                 self.file_dict['File12'] = ''
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmCalibrationData_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmCalibrationData_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmCalibrationData_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmCalibrationData_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmCalibrationData.py
+++ b/src/ui/SWMM/frmCalibrationData.py
@@ -199,6 +199,4 @@ class frmCalibrationData(QMainWindow, Ui_frmCalibrationData):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmCalibrationData_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmCalibrationData_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmClimatology.py
+++ b/src/ui/SWMM/frmClimatology.py
@@ -436,8 +436,6 @@ class frmClimatology(QMainWindow, Ui_frmClimatology):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmClimatology_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmClimatology_state", self.saveState())
         self.close()
 
     def cboEvap_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmClimatology.py
+++ b/src/ui/SWMM/frmClimatology.py
@@ -43,6 +43,13 @@ class frmClimatology(QMainWindow, Ui_frmClimatology):
             if climate_type:
                 self.set_from(main_form.project, climate_type)
 
+        if (main_form.program_settings.value("Geometry/" + "frmClimatology_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmClimatology_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmClimatology_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmClimatology_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, climate_type):
         self.tabClimate_currentTabChanged()
         if climate_type == "Temperature":
@@ -424,9 +431,13 @@ class frmClimatology(QMainWindow, Ui_frmClimatology):
             save_conductivity != adjustments_section.soil_conductivity:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmClimatology_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmClimatology_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmClimatology_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmClimatology_state", self.saveState())
         self.close()
 
     def cboEvap_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmConduits.py
+++ b/src/ui/SWMM/frmConduits.py
@@ -133,6 +133,4 @@ class frmConduits(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmConduits_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmConduits_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmConduits.py
+++ b/src/ui/SWMM/frmConduits.py
@@ -51,6 +51,13 @@ class frmConduits(frmGenericPropertyEditor):
             # also set special text plus button cells
             self.set_cross_section_cell(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmConduits_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmConduits_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmConduits_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmConduits_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -120,7 +127,12 @@ class frmConduits(frmGenericPropertyEditor):
                     value.geometry1 = str(self.tblGeneric.item(6, column).text())
                     value.culvert_code = str(self.tblGeneric.item(18, column).text())
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmConduits_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmConduits_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmConduits_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmConduits_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmControls.py
+++ b/src/ui/SWMM/frmControls.py
@@ -38,6 +38,4 @@ class frmControls(QMainWindow, Ui_frmControls):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmControls_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmControls_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmControls.py
+++ b/src/ui/SWMM/frmControls.py
@@ -16,6 +16,13 @@ class frmControls(QMainWindow, Ui_frmControls):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmControls_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmControls_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmControls_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmControls_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         # section = core.epanet.project.Control()
 
@@ -25,7 +32,12 @@ class frmControls(QMainWindow, Ui_frmControls):
         if str(self.txtControls.toPlainText()) != self._main_form.project.controls.value:
             self._main_form.mark_project_as_unsaved()
         self._main_form.project.controls.value = str(self.txtControls.toPlainText())
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmControls_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmControls_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmControls_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmControls_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmCrossSection.py
+++ b/src/ui/SWMM/frmCrossSection.py
@@ -109,6 +109,13 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
             #self.set_link(main_form.project, '1')
             pass
 
+        if (main_form.program_settings.value("Geometry/" + "frmCrossSection_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmCrossSection_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmCrossSection_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmCrossSection_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_link(self, project, link_name):
         # assume we want to edit the first one
         self.link_name = link_name
@@ -405,9 +412,13 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
             orig_shape != value.shape:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmCrossSection_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmCrossSection_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmCrossSection_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmCrossSection_state", self.saveState())
         self.close()
 
     def btnDialog_Clicked(self):

--- a/src/ui/SWMM/frmCrossSection.py
+++ b/src/ui/SWMM/frmCrossSection.py
@@ -417,8 +417,6 @@ class frmCrossSection(QMainWindow, Ui_frmCrossSection):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmCrossSection_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmCrossSection_state", self.saveState())
         self.close()
 
     def btnDialog_Clicked(self):

--- a/src/ui/SWMM/frmCurveEditor.py
+++ b/src/ui/SWMM/frmCurveEditor.py
@@ -48,6 +48,13 @@ class frmCurveEditor(QMainWindow, Ui_frmCurveEditor):
             else:
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmCurveEditor_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmCurveEditor_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmCurveEditor_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmCurveEditor_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, curve):
         flow_units = self._main_form.project.options.flow_units.name
         if not isinstance(curve, Curve):
@@ -185,9 +192,13 @@ class frmCurveEditor(QMainWindow, Ui_frmCurveEditor):
             orig_xy != self.editing_item.curve_xy:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmCurveEditor_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmCurveEditor_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmCurveEditor_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmCurveEditor_state", self.saveState())
         self.close()
 
     def cboCurveType_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmCurveEditor.py
+++ b/src/ui/SWMM/frmCurveEditor.py
@@ -197,8 +197,6 @@ class frmCurveEditor(QMainWindow, Ui_frmCurveEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmCurveEditor_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmCurveEditor_state", self.saveState())
         self.close()
 
     def cboCurveType_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmDates.py
+++ b/src/ui/SWMM/frmDates.py
@@ -86,6 +86,4 @@ class frmDates(QMainWindow, Ui_frmDates):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmDates_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmDates_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmDates.py
+++ b/src/ui/SWMM/frmDates.py
@@ -19,7 +19,7 @@ class frmDates(QMainWindow, Ui_frmDates):
         if (main_form.program_settings.value("Geometry/" + "frmDates_geometry") and
                 main_form.program_settings.value("Geometry/" + "frmDates_state")):
             self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmDates_geometry",
-                                                                  self.saveGeometry(), type=QtCore.QByteArray))
+                                                                  self.geometry(), type=QtCore.QByteArray))
             self.restoreState(main_form.program_settings.value("Geometry/" + "frmDates_state",
                                                                self.windowState(), type=QtCore.QByteArray))
 

--- a/src/ui/SWMM/frmDefaultsEditor.py
+++ b/src/ui/SWMM/frmDefaultsEditor.py
@@ -448,8 +448,6 @@ class frmDefaultsEditor(QMainWindow, Ui_frmGenericDefaultsEditor):
         discard user changes to the defaults
         Returns:
         """
-        self._main_form.program_settings.setValue("Geometry/" + "frmDefaultsEditor_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmDefaultsEditor_state", self.saveState())
         self.close()
         pass
 

--- a/src/ui/SWMM/frmDefaultsEditor.py
+++ b/src/ui/SWMM/frmDefaultsEditor.py
@@ -106,6 +106,14 @@ class frmDefaultsEditor(QMainWindow, Ui_frmGenericDefaultsEditor):
         self.installEventFilter(self)
         self.loaded = True
 
+        self._main_form = session
+        if (self._main_form.program_settings.value("Geometry/" + "frmDefaultsEditor_geometry") and
+                self._main_form.program_settings.value("Geometry/" + "frmDefaultsEditor_state")):
+            self.restoreGeometry(self._main_form.program_settings.value("Geometry/" + "frmDefaultsEditor_geometry",
+                                                                        self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(self._main_form.program_settings.value("Geometry/" + "frmDefaultsEditor_state",
+                                                                     self.windowState(), type=QtCore.QByteArray))
+
     def resizeCorner(self):
         tab_ind = self.tabDefaults.currentIndex()
         if tab_ind == 0:
@@ -430,6 +438,8 @@ class frmDefaultsEditor(QMainWindow, Ui_frmGenericDefaultsEditor):
             self.session.program_settings.sync()
             pass
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmDefaultsEditor_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmDefaultsEditor_state", self.saveState())
         self.close()
         pass
 
@@ -438,6 +448,8 @@ class frmDefaultsEditor(QMainWindow, Ui_frmGenericDefaultsEditor):
         discard user changes to the defaults
         Returns:
         """
+        self._main_form.program_settings.setValue("Geometry/" + "frmDefaultsEditor_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmDefaultsEditor_state", self.saveState())
         self.close()
         pass
 

--- a/src/ui/SWMM/frmDividers.py
+++ b/src/ui/SWMM/frmDividers.py
@@ -136,6 +136,4 @@ class frmDividers(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmDividers_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmDividers_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmDividers.py
+++ b/src/ui/SWMM/frmDividers.py
@@ -57,6 +57,13 @@ class frmDividers(frmGenericPropertyEditor):
             self.set_inflow_cell(column)
             self.set_treatment_cell(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmDividers_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmDividers_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmDividers_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmDividers_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -123,7 +130,12 @@ class frmDividers(frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmDividers_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmDividers_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmDividers_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmDividers_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmDynamicWave.py
+++ b/src/ui/SWMM/frmDynamicWave.py
@@ -143,6 +143,4 @@ class frmDynamicWave(QMainWindow, Ui_frmDynamicWave):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmDynamicWave_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmDynamicWave_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmDynamicWave.py
+++ b/src/ui/SWMM/frmDynamicWave.py
@@ -28,6 +28,13 @@ class frmDynamicWave(QMainWindow, Ui_frmDynamicWave):
             self.lblSurface.setText("Minimum Nodal Surface Area (sq. feet)")
             self.lblHead.setText("Head Convergence Tolerance (feet)")
 
+        if (main_form.program_settings.value("Geometry/" + "frmDynamicWave_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmDynamicWave_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmDynamicWave_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmDynamicWave_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         # section = core.swmm.options.dynamic_wave.DynamicWave()
         section = project.options.dynamic_wave
@@ -131,7 +138,11 @@ class frmDynamicWave(QMainWindow, Ui_frmDynamicWave):
             int(orig_max_trials) != section.max_trials:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmDynamicWave_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmDynamicWave_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmDynamicWave_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmDynamicWave_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmEvents.py
+++ b/src/ui/SWMM/frmEvents.py
@@ -24,6 +24,13 @@ class frmEvents(QMainWindow, Ui_frmEvents):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmEvents_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmEvents_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmEvents_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmEvents_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         section = project.events
         for event in section.value:
@@ -139,7 +146,11 @@ class frmEvents(QMainWindow, Ui_frmEvents):
                 event.name = event.start_date + event.start_time + event.end_date + event.end_time
                 section.value.append(event)
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmEvents_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmEvents_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmEvents_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmEvents_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmEvents.py
+++ b/src/ui/SWMM/frmEvents.py
@@ -151,6 +151,4 @@ class frmEvents(QMainWindow, Ui_frmEvents):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmEvents_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmEvents_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGeneralOptions.py
+++ b/src/ui/SWMM/frmGeneralOptions.py
@@ -127,6 +127,4 @@ class frmGeneralOptions(QMainWindow, Ui_frmGeneralOptions):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmGeneralOptions_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmGeneralOptions_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGeneralOptions.py
+++ b/src/ui/SWMM/frmGeneralOptions.py
@@ -15,6 +15,13 @@ class frmGeneralOptions(QMainWindow, Ui_frmGeneralOptions):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmGeneralOptions_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmGeneralOptions_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmGeneralOptions_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmGeneralOptions_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         # section = core.swmm.options.general.General()
         section = project.options
@@ -115,7 +122,11 @@ class frmGeneralOptions(QMainWindow, Ui_frmGeneralOptions):
             orig_input != section.input:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmGeneralOptions_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGeneralOptions_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmGeneralOptions_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGeneralOptions_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGroundwaterEquation.py
+++ b/src/ui/SWMM/frmGroundwaterEquation.py
@@ -66,6 +66,4 @@ class frmGroundwaterEquation(QMainWindow, Ui_frmGroundwaterEquation):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquation_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquation_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGroundwaterEquation.py
+++ b/src/ui/SWMM/frmGroundwaterEquation.py
@@ -20,6 +20,13 @@ class frmGroundwaterEquation(QMainWindow, Ui_frmGroundwaterEquation):
         self.cmdCancel.clicked.connect(self.cmdCancel_Clicked)
         self.set_from(main_form.project)
 
+        if (main_form.program_settings.value("Geometry/" + "frmGroundwaterEquation_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmGroundwaterEquation_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmGroundwaterEquation_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmGroundwaterEquation_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         self.project = project
         gwf_section = self.project.gwf
@@ -54,7 +61,11 @@ class frmGroundwaterEquation(QMainWindow, Ui_frmGroundwaterEquation):
             self._main_form.project.gwf.value.append(new_gwf)
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquation_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquation_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquation_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquation_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGroundwaterEquationDeep.py
+++ b/src/ui/SWMM/frmGroundwaterEquationDeep.py
@@ -19,6 +19,13 @@ class frmGroundwaterEquationDeep(QMainWindow, Ui_frmGroundwaterEquationDeep):
         self.cmdCancel.clicked.connect(self.cmdCancel_Clicked)
         self.set_from(main_form.project)
 
+        if (main_form.program_settings.value("Geometry/" + "frmGroundwaterEquationDeep_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmGroundwaterEquationDeep_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmGroundwaterEquationDeep_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmGroundwaterEquationDeep_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         self.project = project
         gwf_section = self.project.gwf
@@ -54,7 +61,15 @@ class frmGroundwaterEquationDeep(QMainWindow, Ui_frmGroundwaterEquationDeep):
             self._main_form.project.gwf.value.append(new_gwf)
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquationDeep_geometry",
+                                                  self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquationDeep_state",
+                                                  self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquationDeep_geometry",
+                                                  self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquationDeep_state",
+                                                  self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGroundwaterEquationDeep.py
+++ b/src/ui/SWMM/frmGroundwaterEquationDeep.py
@@ -68,8 +68,4 @@ class frmGroundwaterEquationDeep(QMainWindow, Ui_frmGroundwaterEquationDeep):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquationDeep_geometry",
-                                                  self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterEquationDeep_state",
-                                                  self.saveState())
         self.close()

--- a/src/ui/SWMM/frmGroundwaterFlow.py
+++ b/src/ui/SWMM/frmGroundwaterFlow.py
@@ -43,6 +43,13 @@ class frmGroundwaterFlow(QMainWindow, Ui_frmGroundwaterFlow):
             self.set_lateral_equation(column)
             self.set_deep_equation(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmGroundwaterFlow_geometry")
+                and main_form.program_settings.value("Geometry/" + "frmGroundwaterFlow_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmGroundwaterFlow_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmGroundwaterFlow_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -106,8 +113,13 @@ class frmGroundwaterFlow(QMainWindow, Ui_frmGroundwaterFlow):
             self.project.groundwater.value.append(self.new_item)
         self.backend.new_item = None
         self.backend.apply_edits()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterFlow_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterFlow_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterFlow_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterFlow_state", self.saveState())
         self.close()
 

--- a/src/ui/SWMM/frmGroundwaterFlow.py
+++ b/src/ui/SWMM/frmGroundwaterFlow.py
@@ -119,7 +119,5 @@ class frmGroundwaterFlow(QMainWindow, Ui_frmGroundwaterFlow):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterFlow_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmGroundwaterFlow_state", self.saveState())
         self.close()
 

--- a/src/ui/SWMM/frmInfiltration.py
+++ b/src/ui/SWMM/frmInfiltration.py
@@ -77,6 +77,14 @@ class frmInfiltration(QMainWindow, Ui_frmInfiltrationEditor):
         self.tblGeneric.verticalHeader().geometriesChanged.connect(self.resizeCorner)
         self.tblGeneric.horizontalHeader().geometriesChanged.connect(self.resizeCorner)
 
+        self._main_form = parent._main_form
+        if (self._main_form.program_settings.value("Geometry/" + "frmInfiltration_geometry") and
+                self._main_form.program_settings.value("Geometry/" + "frmInfiltration_state")):
+            self.restoreGeometry(self._main_form.program_settings.value("Geometry/" + "frmInfiltration_geometry",
+                                                                        self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(self._main_form.program_settings.value("Geometry/" + "frmInfiltration_state",
+                                                                     self.windowState(), type=QtCore.QByteArray))
+
     def cboInfilModel_currentIndexChanged(self, currentIndex):
         #if self.infil_model is None: return
         if not self.defaults: return
@@ -242,8 +250,13 @@ class frmInfiltration(QMainWindow, Ui_frmInfiltrationEditor):
                 elif enum_val == E_InfilModel.GREEN_AMPT:
                     #self.qsettings.setValue(self.default_key, self.infil_model_ga)
                     self.defaults.infil_model_ga.set_defaults()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmInfiltration_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInfiltration_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmInfiltration_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInfiltration_state", self.saveState())
         self.close()
 

--- a/src/ui/SWMM/frmInfiltration.py
+++ b/src/ui/SWMM/frmInfiltration.py
@@ -256,7 +256,5 @@ class frmInfiltration(QMainWindow, Ui_frmInfiltrationEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmInfiltration_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmInfiltration_state", self.saveState())
         self.close()
 

--- a/src/ui/SWMM/frmInflows.py
+++ b/src/ui/SWMM/frmInflows.py
@@ -73,6 +73,13 @@ class frmInflows(QMainWindow, Ui_frmInflows):
         self.setWindowTitle('SWMM Inflows for Node ' + self.node_name)
         self.done_loading = True
 
+        if (main_form.program_settings.value("Geometry/" + "frmInflows_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmInflows_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmInflows_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmInflows_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         self.project = project
         # build a local data structure to hold the data at the present, will need to update as pollutants change
@@ -376,9 +383,14 @@ class frmInflows(QMainWindow, Ui_frmInflows):
                 rdii_section.value = []
             rdii_section.value.append(new_inflow)
             self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmInflows_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInflows_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmInflows_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInflows_state", self.saveState())
         self.close()
 
     def tabInflows_currentTabChanged(self):

--- a/src/ui/SWMM/frmInflows.py
+++ b/src/ui/SWMM/frmInflows.py
@@ -389,8 +389,6 @@ class frmInflows(QMainWindow, Ui_frmInflows):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmInflows_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmInflows_state", self.saveState())
         self.close()
 
     def tabInflows_currentTabChanged(self):

--- a/src/ui/SWMM/frmInitialBuildup.py
+++ b/src/ui/SWMM/frmInitialBuildup.py
@@ -92,6 +92,4 @@ class frmInitialBuildup(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmInitialBuildup_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmInitialBuildup_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmInitialBuildup.py
+++ b/src/ui/SWMM/frmInitialBuildup.py
@@ -50,6 +50,13 @@ class frmInitialBuildup(frmGenericPropertyEditor):
                     self.tblGeneric.setItem(pollutant_count,0,QTableWidgetItem(led.text()))
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmInitialBuildup_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmInitialBuildup_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmInitialBuildup_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmInitialBuildup_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
         section = self._main_form.project.find_section("LOADINGS")
         loadings_list = section.value[0:]
@@ -79,7 +86,12 @@ class frmInitialBuildup(frmGenericPropertyEditor):
                         section.value = []
                     section.value.append(value1)
                     self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmInitialBuildup_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInitialBuildup_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmInitialBuildup_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInitialBuildup_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmInterfaceFiles.py
+++ b/src/ui/SWMM/frmInterfaceFiles.py
@@ -25,6 +25,13 @@ class frmInterfaceFiles(QMainWindow, Ui_frmInterfaceFiles):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmInterfaceFiles_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmInterfaceFiles_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmInterfaceFiles_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmInterfaceFiles_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         # section = core.swmm.options.files.Files()
         section = project.files
@@ -107,6 +114,8 @@ class frmInterfaceFiles(QMainWindow, Ui_frmInterfaceFiles):
             orig_save_outflows != section.save_outflows:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmInterfaceFiles_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInterfaceFiles_state", self.saveState())
         self.close()
 
 
@@ -126,6 +135,8 @@ class frmInterfaceFiles(QMainWindow, Ui_frmInterfaceFiles):
             return None
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmInterfaceFiles_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmInterfaceFiles_state", self.saveState())
         self.close()
 
     def cmdUseRainfall_Clicked(self):

--- a/src/ui/SWMM/frmInterfaceFiles.py
+++ b/src/ui/SWMM/frmInterfaceFiles.py
@@ -135,8 +135,6 @@ class frmInterfaceFiles(QMainWindow, Ui_frmInterfaceFiles):
             return None
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmInterfaceFiles_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmInterfaceFiles_state", self.saveState())
         self.close()
 
     def cmdUseRainfall_Clicked(self):

--- a/src/ui/SWMM/frmJunction.py
+++ b/src/ui/SWMM/frmJunction.py
@@ -101,6 +101,4 @@ class frmJunction(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmJunction_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmJunction_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmJunction.py
+++ b/src/ui/SWMM/frmJunction.py
@@ -24,6 +24,15 @@ class frmJunction(frmGenericPropertyEditor):
             # also set special text plus button cells
             self.set_inflow_cell(column)
             self.set_treatment_cell(column)
+
+        self._main_form = session
+        if (self._main_form.program_settings.value("Geometry/" + "frmJunction_geometry") and
+                self._main_form.program_settings.value("Geometry/" + "frmJunction_state")):
+            self.restoreGeometry(self._main_form.program_settings.value("Geometry/" + "frmJunction_geometry",
+                                                                        self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(self._main_form.program_settings.value("Geometry/" + "frmJunction_state",
+                                                                     self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -86,7 +95,12 @@ class frmJunction(frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self.session.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmJunction_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmJunction_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmJunction_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmJunction_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmLID.py
+++ b/src/ui/SWMM/frmLID.py
@@ -444,8 +444,6 @@ class frmLID(QMainWindow, Ui_frmLID):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmLID_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmLID_state", self.saveState())
         self.close()
 
     def cboLIDType_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmLID.py
+++ b/src/ui/SWMM/frmLID.py
@@ -56,6 +56,13 @@ class frmLID(QMainWindow, Ui_frmLID):
                 self.lid = edit_these
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmLID_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmLID_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmLID_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmLID_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, lid):
         if not isinstance(lid, LIDControl):
             lid = self.section.value[lid]
@@ -432,9 +439,13 @@ class frmLID(QMainWindow, Ui_frmLID):
             orig_removal_removal5 != self.editing_item.removal_removal5:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmLID_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLID_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmLID_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLID_state", self.saveState())
         self.close()
 
     def cboLIDType_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmLIDControls.py
+++ b/src/ui/SWMM/frmLIDControls.py
@@ -26,6 +26,13 @@ class frmLIDControls(QMainWindow, Ui_frmLIDControls):
         self.subcatchment_name = subcatchment_name
         self.set_subcatchment(main_form.project, subcatchment_name)
 
+        if (main_form.program_settings.value("Geometry/" + "frmLIDControls_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmLIDControls_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmLIDControls_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmLIDControls_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_subcatchment(self, project, subcatchment_name):
         # section = core.swmm.project.LIDUsage()
         section = project.lid_usage
@@ -120,9 +127,14 @@ class frmLIDControls(QMainWindow, Ui_frmLIDControls):
                     new_lid.subcatchment_drains_to = self.tblControls.item(row,11).text()
                     section.value.append(new_lid)
             self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmLIDControls_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLIDControls_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmLIDControls_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLIDControls_state", self.saveState())
         self.close()
 
     def btnAdd_Clicked(self):

--- a/src/ui/SWMM/frmLIDControls.py
+++ b/src/ui/SWMM/frmLIDControls.py
@@ -133,8 +133,6 @@ class frmLIDControls(QMainWindow, Ui_frmLIDControls):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmLIDControls_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmLIDControls_state", self.saveState())
         self.close()
 
     def btnAdd_Clicked(self):

--- a/src/ui/SWMM/frmLIDUsage.py
+++ b/src/ui/SWMM/frmLIDUsage.py
@@ -142,8 +142,6 @@ class frmLIDUsage(QMainWindow, Ui_frmLIDUsage):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form._main_form.program_settings.setValue("Geometry/" + "frmLIDUsage_geometry", self.saveGeometry())
-        self._main_form._main_form.program_settings.setValue("Geometry/" + "frmLIDUsage_state", self.saveState())
         self.close()
 
     def cboLIDControl_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmLIDUsage.py
+++ b/src/ui/SWMM/frmLIDUsage.py
@@ -28,6 +28,13 @@ class frmLIDUsage(QMainWindow, Ui_frmLIDUsage):
         self.row_id = -1
         self.project = ''
 
+        if (main_form.program_settings.value("Geometry/" + "frmLIDUsage_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmLIDUsage_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmLIDUsage_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmLIDUsage_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_add(self, project, main_form, subcatchment_name):
         self._main_form = main_form
         self.project = project
@@ -130,9 +137,13 @@ class frmLIDUsage(QMainWindow, Ui_frmLIDUsage):
             self._main_form.SetAreaTerm(self.subcatchment_name, self.row_id, number_replicate_units, area_each_unit)
             self._main_form._main_form.mark_project_as_unsaved()
 
+        self._main_form._main_form.program_settings.setValue("Geometry/" + "frmLIDUsage_geometry", self.saveGeometry())
+        self._main_form._main_form.program_settings.setValue("Geometry/" + "frmLIDUsage_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form._main_form.program_settings.setValue("Geometry/" + "frmLIDUsage_geometry", self.saveGeometry())
+        self._main_form._main_form.program_settings.setValue("Geometry/" + "frmLIDUsage_state", self.saveState())
         self.close()
 
     def cboLIDControl_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmLandUseAssignment.py
+++ b/src/ui/SWMM/frmLandUseAssignment.py
@@ -87,6 +87,4 @@ class frmLandUseAssignment(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmLandUseAssignment_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmLandUseAssignment_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmLandUseAssignment.py
+++ b/src/ui/SWMM/frmLandUseAssignment.py
@@ -45,6 +45,13 @@ class frmLandUseAssignment(frmGenericPropertyEditor):
                     self.tblGeneric.setItem(land_use_count,0,QTableWidgetItem(led.text()))
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmLandUseAssignment_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmLandUseAssignment_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmLandUseAssignment_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmLandUseAssignment_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
         section = self._main_form.project.find_section("COVERAGES")
         coverage_list = section.value[0:]
@@ -74,7 +81,12 @@ class frmLandUseAssignment(frmGenericPropertyEditor):
                         section.value = []
                     section.value.append(value1)
                     self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUseAssignment_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUseAssignment_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUseAssignment_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUseAssignment_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmLandUses.py
+++ b/src/ui/SWMM/frmLandUses.py
@@ -55,6 +55,13 @@ class frmLandUses(QMainWindow, Ui_frmLandUsesEditor):
         self.tblGeneral.resizeRowToContents(1)
         self.resize(400,450)
 
+        if (main_form.program_settings.value("Geometry/" + "frmLandUses_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmLandUses_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmLandUses_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmLandUses_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, land_use):
         if not isinstance(land_use, Landuse):
             land_use = self.section.value[land_use]
@@ -279,9 +286,13 @@ class frmLandUses(QMainWindow, Ui_frmLandUsesEditor):
             pass
             # TODO: self._main_form.edited_?
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUses_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUses_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUses_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmLandUses_state", self.saveState())
         self.close()
 
     def tblGeneral_currentCellChanged(self):

--- a/src/ui/SWMM/frmLandUses.py
+++ b/src/ui/SWMM/frmLandUses.py
@@ -291,8 +291,6 @@ class frmLandUses(QMainWindow, Ui_frmLandUsesEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmLandUses_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmLandUses_state", self.saveState())
         self.close()
 
     def tblGeneral_currentCellChanged(self):

--- a/src/ui/SWMM/frmMapBackdropOptions.py
+++ b/src/ui/SWMM/frmMapBackdropOptions.py
@@ -16,6 +16,13 @@ class frmMapBackdropOptions(QMainWindow, Ui_frmMapBackdropOptions):
         self._main_form = main_form
         self.set_from(main_form.project)
 
+        if (main_form.program_settings.value("Geometry/" + "frmMapBackdropOptions_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmMapBackdropOptions_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmMapBackdropOptions_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmMapBackdropOptions_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         # section = core.swmm.options.backdrop.BackdropOptions()
         section = project.backdrop
@@ -86,7 +93,11 @@ class frmMapBackdropOptions(QMainWindow, Ui_frmMapBackdropOptions):
             orig_dimensions != section.dimensions:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmMapBackdropOptions_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmMapBackdropOptions_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmMapBackdropOptions_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmMapBackdropOptions_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmMapBackdropOptions.py
+++ b/src/ui/SWMM/frmMapBackdropOptions.py
@@ -98,6 +98,4 @@ class frmMapBackdropOptions(QMainWindow, Ui_frmMapBackdropOptions):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmMapBackdropOptions_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmMapBackdropOptions_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmOrifices.py
+++ b/src/ui/SWMM/frmOrifices.py
@@ -108,6 +108,4 @@ class frmOrifices(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmOrifices_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmOrifices_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmOrifices.py
+++ b/src/ui/SWMM/frmOrifices.py
@@ -62,6 +62,14 @@ class frmOrifices(frmGenericPropertyEditor):
                         combobox.setCurrentIndex(1)
                     self.tblGeneric.setItem(7, column, QTableWidgetItem(value.geometry1))
                     self.tblGeneric.setItem(8, column, QTableWidgetItem(value.geometry2))
+
+        if (main_form.program_settings.value("Geometry/" + "frmOrifices_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmOrifices_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmOrifices_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmOrifices_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -94,7 +102,12 @@ class frmOrifices(frmGenericPropertyEditor):
                     value.geometry2 = current_geometry2_text
         self._main_form.list_objects()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmOrifices_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmOrifices_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmOrifices_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmOrifices_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmOutfalls.py
+++ b/src/ui/SWMM/frmOutfalls.py
@@ -84,6 +84,13 @@ class frmOutfalls(frmGenericPropertyEditor):
             self.set_inflow_cell(column)
             self.set_treatment_cell(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmOutfalls_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmOutfalls_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmOutfalls_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmOutfalls_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -154,7 +161,12 @@ class frmOutfalls(frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutfalls_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutfalls_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutfalls_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutfalls_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmOutfalls.py
+++ b/src/ui/SWMM/frmOutfalls.py
@@ -167,6 +167,4 @@ class frmOutfalls(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmOutfalls_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmOutfalls_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmOutlets.py
+++ b/src/ui/SWMM/frmOutlets.py
@@ -60,6 +60,13 @@ class frmOutlets(frmGenericPropertyEditor):
             combobox.setCurrentIndex(selected_index)
             self.tblGeneric.setCellWidget(10, column, combobox)
 
+        if (main_form.program_settings.value("Geometry/" + "frmOutlets_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmOutlets_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmOutlets_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmOutlets_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -71,7 +78,12 @@ class frmOutlets(frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutlets_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutlets_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutlets_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmOutlets_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmOutlets.py
+++ b/src/ui/SWMM/frmOutlets.py
@@ -84,6 +84,4 @@ class frmOutlets(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmOutlets_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmOutlets_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmPatternEditor.py
+++ b/src/ui/SWMM/frmPatternEditor.py
@@ -114,8 +114,6 @@ class frmPatternEditor(QMainWindow, Ui_frmPatternEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmPatternEditor_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmPatternEditor_state", self.saveState())
         self.close()
 
     def cboType_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmPatternEditor.py
+++ b/src/ui/SWMM/frmPatternEditor.py
@@ -31,6 +31,13 @@ class frmPatternEditor(QMainWindow, Ui_frmPatternEditor):
             else:
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmPatternEditor_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmPatternEditor_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmPatternEditor_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmPatternEditor_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, pattern):
         if not isinstance(pattern, Pattern):
             pattern = self.section.value[pattern]
@@ -101,9 +108,14 @@ class frmPatternEditor(QMainWindow, Ui_frmPatternEditor):
 
         # regardless if pattern id is changed, refresh pattern references at all places
         self._main_form.project.refresh_pattern_object_references()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmPatternEditor_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmPatternEditor_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmPatternEditor_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmPatternEditor_state", self.saveState())
         self.close()
 
     def cboType_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmPumps.py
+++ b/src/ui/SWMM/frmPumps.py
@@ -61,6 +61,13 @@ class frmPumps(frmGenericPropertyEditor):
                     combobox.setCurrentIndex(0)
             self.tblGeneric.setCellWidget(6, column, combobox)
 
+        if (main_form.program_settings.value("Geometry/" + "frmPumps_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmPumps_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmPumps_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmPumps_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -72,7 +79,12 @@ class frmPumps(frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmPumps_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmPumps_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmPumps_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmPumps_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmPumps.py
+++ b/src/ui/SWMM/frmPumps.py
@@ -85,6 +85,4 @@ class frmPumps(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmPumps_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmPumps_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmRainGages.py
+++ b/src/ui/SWMM/frmRainGages.py
@@ -31,10 +31,23 @@ class frmRainGages(frmGenericPropertyEditor):
             combobox.setCurrentIndex(selected_index)
             self.tblGeneric.setCellWidget(9, column, combobox)
 
+        self._main_form = session
+        if (self._main_form.program_settings.value("Geometry/" + "frmRainGages_geometry") and
+                self._main_form.program_settings.value("Geometry/" + "frmRainGages_state")):
+            self.restoreGeometry(self._main_form.program_settings.value("Geometry/" + "frmRainGages_geometry",
+                                                                        self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(self._main_form.program_settings.value("Geometry/" + "frmRainGages_state",
+                                                                     self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self.session.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmRainGages_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmRainGages_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmRainGages_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmRainGages_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmRainGages.py
+++ b/src/ui/SWMM/frmRainGages.py
@@ -48,6 +48,4 @@ class frmRainGages(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmRainGages_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmRainGages_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmReportOptions.py
+++ b/src/ui/SWMM/frmReportOptions.py
@@ -21,6 +21,13 @@ class frmReportOptions(QMainWindow, Ui_frmReportOptions):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmReportOptions_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmReportOptions_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmReportOptions_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmReportOptions_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         # section = core.swmm.options.report.Report()
         section = project.find_section("REPORT")
@@ -98,9 +105,13 @@ class frmReportOptions(QMainWindow, Ui_frmReportOptions):
             orig_averages != section.averages:
             self._main_form.mark_project_as_unsaved()
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmReportOptions_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmReportOptions_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmReportOptions_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmReportOptions_state", self.saveState())
         self.close()
 
     def cmdNodeAll_Clicked(self):

--- a/src/ui/SWMM/frmReportOptions.py
+++ b/src/ui/SWMM/frmReportOptions.py
@@ -110,8 +110,6 @@ class frmReportOptions(QMainWindow, Ui_frmReportOptions):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmReportOptions_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmReportOptions_state", self.saveState())
         self.close()
 
     def cmdNodeAll_Clicked(self):

--- a/src/ui/SWMM/frmScatterPlot.py
+++ b/src/ui/SWMM/frmScatterPlot.py
@@ -107,6 +107,4 @@ class frmScatterPlot(QMainWindow, Ui_frmScatterPlot):
         self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_state", self.saveState())
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmScatterPlot.py
+++ b/src/ui/SWMM/frmScatterPlot.py
@@ -21,6 +21,13 @@ class frmScatterPlot(QMainWindow, Ui_frmScatterPlot):
         self.cboXCat.currentIndexChanged.connect(self.cboXCat_currentIndexChanged)
         self.cboYCat.currentIndexChanged.connect(self.cboYCat_currentIndexChanged)
 
+        if (main_form.program_settings.value("Geometry/" + "frmScatterPlot_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmScatterPlot_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmScatterPlot_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmScatterPlot_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, output):
         self.project = project
         self.output = output
@@ -96,5 +103,10 @@ class frmScatterPlot(QMainWindow, Ui_frmScatterPlot):
                                    object_type_label_x, object_name_x, attribute_name_x,
                                    object_type_label_y, object_name_y, attribute_name_y, start_index, num_steps)
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_state", self.saveState())
+
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmScatterPlot_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSeepage.py
+++ b/src/ui/SWMM/frmSeepage.py
@@ -102,8 +102,6 @@ class frmSeepage(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmSeepage_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmSeepage_state", self.saveState())
         self.close()
 
     def table_currentCellChanged(self):

--- a/src/ui/SWMM/frmSeepage.py
+++ b/src/ui/SWMM/frmSeepage.py
@@ -67,6 +67,13 @@ class frmSeepage(frmGenericPropertyEditor):
         self.resize(280,300)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmSeepage_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmSeepage_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmSeepage_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmSeepage_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
         node_found = False
         for storage_node in self.storage_nodes_list:
@@ -89,9 +96,14 @@ class frmSeepage(frmGenericPropertyEditor):
             value1.seepage_initial_moisture_deficit = self.tblGeneric.item(2, 0).text()
             self.section.value.append(value1)
             self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmSeepage_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSeepage_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmSeepage_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSeepage_state", self.saveState())
         self.close()
 
     def table_currentCellChanged(self):

--- a/src/ui/SWMM/frmSnowPack.py
+++ b/src/ui/SWMM/frmSnowPack.py
@@ -25,6 +25,13 @@ class frmSnowPack(QMainWindow, Ui_frmSnowPack):
             else:
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmSnowPack_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmSnowPack_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmSnowPack_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmSnowPack_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, pack):
         if not isinstance(pack, SnowPack):
             pack = self.section.value[pack]
@@ -167,7 +174,12 @@ class frmSnowPack(QMainWindow, Ui_frmSnowPack):
             self._main_form.mark_project_as_unsaved()
         else:
             pass
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmSnowPack_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSnowPack_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmSnowPack_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSnowPack_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSnowPack.py
+++ b/src/ui/SWMM/frmSnowPack.py
@@ -180,6 +180,4 @@ class frmSnowPack(QMainWindow, Ui_frmSnowPack):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmSnowPack_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmSnowPack_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmStatisticsReport.py
+++ b/src/ui/SWMM/frmStatisticsReport.py
@@ -491,8 +491,6 @@ class frmStatisticsReport(QMainWindow, Ui_frmStatisticsReport):
         self.widgetFrequency = frequency
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReport_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReport_state", self.saveState())
         self.close()
 
 class MyHistogram(FigureCanvas):

--- a/src/ui/SWMM/frmStatisticsReport.py
+++ b/src/ui/SWMM/frmStatisticsReport.py
@@ -50,6 +50,13 @@ class frmStatisticsReport(QMainWindow, Ui_frmStatisticsReport):
         self.stats = None
         self.statsResult = None #UStats.TStatsResults()
 
+        if (main_form.program_settings.value("Geometry/" + "frmStatisticsReport_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmStatisticsReport_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmStatisticsReport_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmStatisticsReport_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, output, stats):
         self.project = project
         self.output = output #SMO.SwmmOutputObject(output)
@@ -484,6 +491,8 @@ class frmStatisticsReport(QMainWindow, Ui_frmStatisticsReport):
         self.widgetFrequency = frequency
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReport_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReport_state", self.saveState())
         self.close()
 
 class MyHistogram(FigureCanvas):

--- a/src/ui/SWMM/frmStatisticsReportSelection.py
+++ b/src/ui/SWMM/frmStatisticsReportSelection.py
@@ -30,6 +30,13 @@ class frmStatisticsReportSelection(QMainWindow, Ui_frmStatisticsReportSelection)
         self.txtMinEventDelta.setText('6')
         self.stats = ostatistics.TStatsSelection()
 
+        if (main_form.program_settings.value("Geometry/" + "frmStatisticsReportSelection_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmStatisticsReportSelection_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmStatisticsReportSelection_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmStatisticsReportSelection_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, output):
         self.project = project
         self.output = output
@@ -147,8 +154,17 @@ class frmStatisticsReportSelection(QMainWindow, Ui_frmStatisticsReportSelection)
         #     self.separation_time = separation_time  # 6
 
         self._frmStatisticsReport.show()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReportSelection_geometry",
+                                                  self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReportSelection_state",
+                                                  self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReportSelection_geometry",
+                                                  self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReportSelection_state",
+                                                  self.saveState())
         self.close()
 

--- a/src/ui/SWMM/frmStatisticsReportSelection.py
+++ b/src/ui/SWMM/frmStatisticsReportSelection.py
@@ -162,9 +162,5 @@ class frmStatisticsReportSelection(QMainWindow, Ui_frmStatisticsReportSelection)
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReportSelection_geometry",
-                                                  self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmStatisticsReportSelection_state",
-                                                  self.saveState())
         self.close()
 

--- a/src/ui/SWMM/frmStorageUnits.py
+++ b/src/ui/SWMM/frmStorageUnits.py
@@ -59,6 +59,13 @@ class frmStorageUnits(frmGenericPropertyEditor):
             self.set_inflow_cell(column)
             self.set_treatment_cell(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmStorageUnits_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmStorageUnits_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmStorageUnits_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmStorageUnits_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -151,7 +158,12 @@ class frmStorageUnits(frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmStorageUnits_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmStorageUnits_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmStorageUnits_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmStorageUnits_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmStorageUnits.py
+++ b/src/ui/SWMM/frmStorageUnits.py
@@ -164,6 +164,4 @@ class frmStorageUnits(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmStorageUnits_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmStorageUnits_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSubcatchments.py
+++ b/src/ui/SWMM/frmSubcatchments.py
@@ -384,6 +384,4 @@ class frmSubcatchments(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmSubcatchments_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmSubcatchments_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSubcatchments.py
+++ b/src/ui/SWMM/frmSubcatchments.py
@@ -136,6 +136,13 @@ class frmSubcatchments(frmGenericPropertyEditor):
             # also set special text plus button cells
             self.set_special_cells(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmSubcatchments_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmSubcatchments_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmSubcatchments_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmSubcatchments_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def set_special_cells(self, column):
@@ -372,7 +379,11 @@ class frmSubcatchments(frmGenericPropertyEditor):
                 # not found already and not blank, add it
                 adjustments.infil.append(subname + "                " + infil_pattern)
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmSubcatchments_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSubcatchments_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmSubcatchments_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSubcatchments_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSummary.py
+++ b/src/ui/SWMM/frmSummary.py
@@ -68,6 +68,4 @@ class frmSummary(QMainWindow, Ui_frmSummary):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmSummary_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmSummary_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSummary.py
+++ b/src/ui/SWMM/frmSummary.py
@@ -16,6 +16,13 @@ class frmSummary(QMainWindow, Ui_frmSummary):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmSummary_geometry")
+                and main_form.program_settings.value("Geometry/" + "frmSummary_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmSummary_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmSummary_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         self.txtTitle.setText(str(project.title.title))
         self.txtNotes.setPlainText(str(project.title.comment))
@@ -55,7 +62,12 @@ class frmSummary(QMainWindow, Ui_frmSummary):
 
         section.title = self.txtTitle.text()
         section.comment = self.txtNotes.toPlainText()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmSummary_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSummary_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmSummary_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSummary_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSummaryReport.py
+++ b/src/ui/SWMM/frmSummaryReport.py
@@ -292,6 +292,4 @@ class frmSummaryReport(QMainWindow, Ui_frmSummaryReport):
                 print("Error reading " + self.status_file_name)
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmSummaryReport_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmSummaryReport_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmSummaryReport.py
+++ b/src/ui/SWMM/frmSummaryReport.py
@@ -20,6 +20,13 @@ class frmSummaryReport(QMainWindow, Ui_frmSummaryReport):
         self.cboType.currentIndexChanged.connect(self.cboType_currentIndexChanged)
         self.tblSummary.setSortingEnabled(False)
 
+        if (main_form.program_settings.value("Geometry/" + "frmSummaryReport_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmSummaryReport_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmSummaryReport_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmSummaryReport_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, status_file_name):
         self.project = project
         self.status_file_name = status_file_name
@@ -285,4 +292,6 @@ class frmSummaryReport(QMainWindow, Ui_frmSummaryReport):
                 print("Error reading " + self.status_file_name)
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmSummaryReport_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmSummaryReport_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTableSelection.py
+++ b/src/ui/SWMM/frmTableSelection.py
@@ -102,8 +102,6 @@ class frmTableSelection(QMainWindow, Ui_frmTableSelection):
         # self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTableSelection_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTableSelection_state", self.saveState())
         self.close()
 
     def cboObject_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmTableSelection.py
+++ b/src/ui/SWMM/frmTableSelection.py
@@ -24,6 +24,13 @@ class frmTableSelection(QMainWindow, Ui_frmTableSelection):
         self.lstNodes.setSelectionMode(QAbstractItemView.MultiSelection)
         self.lstVariables.setSelectionMode(QAbstractItemView.MultiSelection)
 
+        if (main_form.program_settings.value("Geometry/" + "frmTableSelection_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTableSelection_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTableSelection_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTableSelection_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, output):
         self.project = project
         self.output = output
@@ -95,6 +102,8 @@ class frmTableSelection(QMainWindow, Ui_frmTableSelection):
         # self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTableSelection_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTableSelection_state", self.saveState())
         self.close()
 
     def cboObject_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmTimeSeriesPlot.py
+++ b/src/ui/SWMM/frmTimeSeriesPlot.py
@@ -30,6 +30,15 @@ class frmTimeSeriesPlot(QMainWindow, Ui_frmTimeSeriesPlot):
         self.btnScript.clicked.connect(self.save_script)
         self.cboStart.currentIndexChanged.connect(self.cboStart_currentIndexChanged)
         self.cboEnd.currentIndexChanged.connect(self.cboEnd_currentIndexChanged)
+
+        self._main_form = session
+        if (self._main_form.program_settings.value("Geometry/" + "frmTimeSeriesPlot_geometry") and
+                self._main_form.program_settings.value("Geometry/" + "frmTimeSeriesPlot_state")):
+            self.restoreGeometry(self._main_form.program_settings.value("Geometry/" + "frmTimeSeriesPlot_geometry",
+                                                                        self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(self._main_form.program_settings.value("Geometry/" + "frmTimeSeriesPlot_state",
+                                                                     self.windowState(), type=QtCore.QByteArray))
+
         # self.installEventFilter(self)
 
     def set_from(self, project, output):
@@ -96,6 +105,9 @@ class frmTimeSeriesPlot(QMainWindow, Ui_frmTimeSeriesPlot):
                                     "Error plotting:\n" + msg,
                                     QMessageBox.Ok)
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesPlot_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesPlot_state", self.saveState())
+
         # cb = QApplication.clipboard()
         # cb.clear(mode=cb.Clipboard)
         # cb.setText(self.get_text(), mode=cb.Clipboard)
@@ -131,6 +143,8 @@ class frmTimeSeriesPlot(QMainWindow, Ui_frmTimeSeriesPlot):
                 print("Error writing {0}: {1}\n{2}".format(file_name, str(e), str(traceback.print_exc())))
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesPlot_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesPlot_state", self.saveState())
         self.close()
 
     def get_text_lines(self):

--- a/src/ui/SWMM/frmTimeSeriesPlot.py
+++ b/src/ui/SWMM/frmTimeSeriesPlot.py
@@ -143,8 +143,6 @@ class frmTimeSeriesPlot(QMainWindow, Ui_frmTimeSeriesPlot):
                 print("Error writing {0}: {1}\n{2}".format(file_name, str(e), str(traceback.print_exc())))
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesPlot_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesPlot_state", self.saveState())
         self.close()
 
     def get_text_lines(self):

--- a/src/ui/SWMM/frmTimeSeriesSelection.py
+++ b/src/ui/SWMM/frmTimeSeriesSelection.py
@@ -22,6 +22,13 @@ class frmTimeSeriesSelection(QMainWindow, Ui_frmTimeSeriesSelection):
         self.onObjectSelected = self._main_form.objectsSelected
         self.onObjectSelected.connect(self.set_selected_object)
 
+        if (main_form.program_settings.value("Geometry/" + "frmTimeSeriesSelection_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTimeSeriesSelection_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTimeSeriesSelection_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTimeSeriesSelection_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project, output, listener):
         self.project = project
         self.output = output
@@ -109,7 +116,12 @@ class frmTimeSeriesSelection(QMainWindow, Ui_frmTimeSeriesSelection):
                       self.cboVariable.currentText(),
                       axis,
                       legend)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesSelection_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesSelection_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesSelection_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesSelection_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTimeSeriesSelection.py
+++ b/src/ui/SWMM/frmTimeSeriesSelection.py
@@ -122,6 +122,4 @@ class frmTimeSeriesSelection(QMainWindow, Ui_frmTimeSeriesSelection):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesSelection_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSeriesSelection_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTimeSteps.py
+++ b/src/ui/SWMM/frmTimeSteps.py
@@ -120,6 +120,4 @@ class frmTimeSteps(QMainWindow, Ui_frmTimeSteps):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSteps_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSteps_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTimeSteps.py
+++ b/src/ui/SWMM/frmTimeSteps.py
@@ -16,6 +16,13 @@ class frmTimeSteps(QMainWindow, Ui_frmTimeSteps):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmTimeSteps_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTimeSteps_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTimeSteps_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTimeSteps_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         section = project.options.time_steps
         self.cbxSkip.setChecked(section.skip_steady_state)
@@ -107,7 +114,12 @@ class frmTimeSteps(QMainWindow, Ui_frmTimeSteps):
             orig_second != routing_time.second() or \
             orig_rule_step != section.rule_step:
             self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSteps_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSteps_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSteps_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeSteps_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTimeseries.py
+++ b/src/ui/SWMM/frmTimeseries.py
@@ -37,6 +37,13 @@ class frmTimeseries(QMainWindow, Ui_frmTimeseries):
             else:
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmTimeseries_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTimeseries_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTimeseries_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTimeseries_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, timeseries):
         if not isinstance(timeseries, TimeSeries):
             timeseries = self.section.value[timeseries]
@@ -171,9 +178,14 @@ class frmTimeseries(QMainWindow, Ui_frmTimeseries):
                 self._main_form.mark_project_as_unsaved()
             pass
             # TODO: self._main_form.edited_?
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeseries_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeseries_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeseries_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTimeseries_state", self.saveState())
         self.close()
 
     def btnFile_Clicked(self):

--- a/src/ui/SWMM/frmTimeseries.py
+++ b/src/ui/SWMM/frmTimeseries.py
@@ -184,8 +184,6 @@ class frmTimeseries(QMainWindow, Ui_frmTimeseries):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeseries_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTimeseries_state", self.saveState())
         self.close()
 
     def btnFile_Clicked(self):

--- a/src/ui/SWMM/frmTitle.py
+++ b/src/ui/SWMM/frmTitle.py
@@ -36,6 +36,4 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTitle.py
+++ b/src/ui/SWMM/frmTitle.py
@@ -14,6 +14,14 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         self.set_from(main_form.project)
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmTitle_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTitle_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTitle_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTitle_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
+
     def set_from(self, project):
         self.txtTitle.setPlainText(project.title.title)
 
@@ -22,7 +30,12 @@ class frmTitle(QMainWindow, Ui_frmTitle):
         if section.title != self.txtTitle.toPlainText():
             self._main_form.mark_project_as_unsaved()
         section.title = self.txtTitle.toPlainText()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTitle_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTransect.py
+++ b/src/ui/SWMM/frmTransect.py
@@ -31,6 +31,13 @@ class frmTransect(QMainWindow, Ui_frmTransect):
             else:
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmTransect_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTransect_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTransect_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTransect_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, transect):
         if not isinstance(transect, Transect):
             transect = self.section.value[transect]
@@ -108,9 +115,13 @@ class frmTransect(QMainWindow, Ui_frmTransect):
                 self._main_form.mark_project_as_unsaved()
             pass
 
+        self._main_form.program_settings.setValue("Geometry/" + "frmTransect_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTransect_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTransect_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTransect_state", self.saveState())
         self.close()
 
     def btnView_Clicked(self):

--- a/src/ui/SWMM/frmTransect.py
+++ b/src/ui/SWMM/frmTransect.py
@@ -120,8 +120,6 @@ class frmTransect(QMainWindow, Ui_frmTransect):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTransect_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTransect_state", self.saveState())
         self.close()
 
     def btnView_Clicked(self):

--- a/src/ui/SWMM/frmTreatment.py
+++ b/src/ui/SWMM/frmTreatment.py
@@ -90,6 +90,4 @@ class frmTreatment(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmTreatment_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmTreatment_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmTreatment.py
+++ b/src/ui/SWMM/frmTreatment.py
@@ -48,6 +48,13 @@ class frmTreatment(frmGenericPropertyEditor):
                     self.tblGeneric.setItem(pollutant_count,0,QTableWidgetItem(led.text()))
         self._main_form = main_form
 
+        if (main_form.program_settings.value("Geometry/" + "frmTreatment_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmTreatment_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmTreatment_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmTreatment_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def cmdOK_Clicked(self):
         section = self._main_form.project.find_section("TREATMENT")
         treatment_list = section.value[0:]
@@ -77,7 +84,12 @@ class frmTreatment(frmGenericPropertyEditor):
                         section.value = []
                     section.value.append(value1)
                     self._main_form.mark_project_as_unsaved()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmTreatment_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTreatment_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmTreatment_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmTreatment_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmUnitHydrograph.py
+++ b/src/ui/SWMM/frmUnitHydrograph.py
@@ -198,8 +198,6 @@ class frmUnitHydrograph(QMainWindow, Ui_frmUnitHydrograph):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmUnitHydrograph_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmUnitHydrograph_state", self.saveState())
         self.close()
 
     def cboHydrograph_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmUnitHydrograph.py
+++ b/src/ui/SWMM/frmUnitHydrograph.py
@@ -30,6 +30,13 @@ class frmUnitHydrograph(QMainWindow, Ui_frmUnitHydrograph):
             else:
                 self.set_from(edit_these)
 
+        if (main_form.program_settings.value("Geometry/" + "frmUnitHydrograph_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmUnitHydrograph_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmUnitHydrograph_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmUnitHydrograph_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, hydrograph):
         if not isinstance(hydrograph, UnitHydrograph):
             hydrograph = self.section.value[hydrograph]
@@ -185,9 +192,14 @@ class frmUnitHydrograph(QMainWindow, Ui_frmUnitHydrograph):
                         value.initial_abstraction_amount != self.editing_item.value[count].initial_abstraction_amount:
                         self._main_form.mark_project_as_unsaved()
             pass
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmUnitHydrograph_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmUnitHydrograph_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmUnitHydrograph_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmUnitHydrograph_state", self.saveState())
         self.close()
 
     def cboHydrograph_currentIndexChanged(self, newIndex):

--- a/src/ui/SWMM/frmWeirs.py
+++ b/src/ui/SWMM/frmWeirs.py
@@ -72,6 +72,13 @@ class frmWeirs(frmGenericPropertyEditor):
             self.tblGeneric.setCellWidget(15, column, combobox)
             self.set_cross_section_cells(column)
 
+        if (main_form.program_settings.value("Geometry/" + "frmWeirs_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmWeirs_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmWeirs_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmWeirs_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
         self.installEventFilter(self)
 
     def eventFilter(self, ui_object, event):
@@ -138,7 +145,12 @@ class frmWeirs(frmGenericPropertyEditor):
                         orig_geometry3 != value.geometry3:
                         self._main_form.mark_project_as_unsaved()
         # self._main_form.model_layers.create_layers_from_project(self.project)
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmWeirs_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmWeirs_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        self._main_form.program_settings.setValue("Geometry/" + "frmWeirs_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmWeirs_state", self.saveState())
         self.close()

--- a/src/ui/SWMM/frmWeirs.py
+++ b/src/ui/SWMM/frmWeirs.py
@@ -151,6 +151,4 @@ class frmWeirs(frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        self._main_form.program_settings.setValue("Geometry/" + "frmWeirs_geometry", self.saveGeometry())
-        self._main_form.program_settings.setValue("Geometry/" + "frmWeirs_state", self.saveState())
         self.close()

--- a/src/ui/frmGenericPropertyEditor.py
+++ b/src/ui/frmGenericPropertyEditor.py
@@ -106,13 +106,6 @@ class frmGenericPropertyEditor(QMainWindow, Ui_frmGenericPropertyEditor):
         self.close()
 
     def cmdCancel_Clicked(self):
-        if self._main_form.model == 'SWMM':
-            if self.project_section.SECTION_NAME == '[LABELS]' or self.project_section.SECTION_NAME == '[POLLUTANTS]':
-                word = self.project_section.SECTION_NAME.strip('[]')
-                self._main_form.program_settings.setValue("Geometry/" + "frmGenericPropertyEditor_" + word +
-                                                          "_geometry", self.saveGeometry())
-                self._main_form.program_settings.setValue("Geometry/" + "frmGenericPropertyEditor_" + word +
-                                                          "_state", self.saveState())
         self.close()
 
     def copy(self):

--- a/src/ui/frmGenericPropertyEditor.py
+++ b/src/ui/frmGenericPropertyEditor.py
@@ -40,6 +40,20 @@ class frmGenericPropertyEditor(QMainWindow, Ui_frmGenericPropertyEditor):
         for row in range(self.tblGeneric.rowCount()):
             self.tblGeneric.setRowHeight(row, 20)
 
+        self._main_form = session
+        if session.model == 'SWMM':
+            if project_section.SECTION_NAME == '[LABELS]' or project_section.SECTION_NAME == '[POLLUTANTS]':
+                word = project_section.SECTION_NAME.strip('[]')
+
+                if (session.program_settings.value("Geometry/" + "frmGenericPropertyEditor_" + word + "_geometry") and
+                        session.program_settings.value("Geometry/" + "frmGenericPropertyEditor_" + word + "_state")):
+                    self.restoreGeometry(
+                        session.program_settings.value("Geometry/" + "frmGenericPropertyEditor_" + word +
+                                                       "_geometry", self.geometry(), type=QtCore.QByteArray))
+                    self.restoreState(
+                        session.program_settings.value("Geometry/" + "frmGenericPropertyEditor_" + word +
+                                                       "_state", self.windowState(), type=QtCore.QByteArray))
+
     def header_index(self, prop):
         """
         Look up the row header to match up with prop
@@ -81,9 +95,24 @@ class frmGenericPropertyEditor(QMainWindow, Ui_frmGenericPropertyEditor):
     def cmdOK_Clicked(self):
         self.backend.apply_edits()
         # self.session.model_layers.create_layers_from_project(self.project)
+
+        if self._main_form.model == 'SWMM':
+            if self.project_section.SECTION_NAME == '[LABELS]' or self.project_section.SECTION_NAME == '[POLLUTANTS]':
+                word = self.project_section.SECTION_NAME.strip('[]')
+                self._main_form.program_settings.setValue("Geometry/" + "frmGenericPropertyEditor_" + word +
+                                                          "_geometry", self.saveGeometry())
+                self._main_form.program_settings.setValue("Geometry/" + "frmGenericPropertyEditor_" + word +
+                                                          "_state", self.saveState())
         self.close()
 
     def cmdCancel_Clicked(self):
+        if self._main_form.model == 'SWMM':
+            if self.project_section.SECTION_NAME == '[LABELS]' or self.project_section.SECTION_NAME == '[POLLUTANTS]':
+                word = self.project_section.SECTION_NAME.strip('[]')
+                self._main_form.program_settings.setValue("Geometry/" + "frmGenericPropertyEditor_" + word +
+                                                          "_geometry", self.saveGeometry())
+                self._main_form.program_settings.setValue("Geometry/" + "frmGenericPropertyEditor_" + word +
+                                                          "_state", self.saveState())
         self.close()
 
     def copy(self):

--- a/src/ui/frmMain.py
+++ b/src/ui/frmMain.py
@@ -376,13 +376,12 @@ class frmMain(QMainWindow, Ui_frmMain):
         self.actionStdCopy_To.setVisible(False)
         self.actionStdGroup_Edit.setVisible(False)
 
-        if self.model == 'SWMM':
-            if (self.program_settings.value("Geometry/" + "frmMainSWMM_geometry") and
-                    self.program_settings.value("Geometry/" + "frmMainSWMM_state")):
-                self.restoreGeometry(self.program_settings.value("Geometry/" + "frmMainSWMM_geometry",
-                                                                 self.geometry(), type=QtCore.QByteArray))
-                self.restoreState(self.program_settings.value("Geometry/" + "frmMainSWMM_state",
-                                                              self.windowState(), type=QtCore.QByteArray))
+        if (self.program_settings.value("Geometry/" + "frmMain_geometry") and
+                self.program_settings.value("Geometry/" + "frmMain_state")):
+            self.restoreGeometry(self.program_settings.value("Geometry/" + "frmMain_geometry",
+                                                             self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(self.program_settings.value("Geometry/" + "frmMain_state",
+                                                          self.windowState(), type=QtCore.QByteArray))
 
     def loadBasemap(self):
         pass
@@ -2416,9 +2415,8 @@ class frmMain(QMainWindow, Ui_frmMain):
         if not self.confirm_discard_project():
             return
 
-        if self.model == 'SWMM':
-            self.program_settings.setValue("Geometry/" + "frmMainSWMM_geometry", self.saveGeometry())
-            self.program_settings.setValue("Geometry/" + "frmMainSWMM_state", self.saveState())
+        self.program_settings.setValue("Geometry/" + "frmMain_geometry", self.saveGeometry())
+        self.program_settings.setValue("Geometry/" + "frmMain_state", self.saveState())
 
         del self.program_settings
         del self.project_settings

--- a/src/ui/frmMain.py
+++ b/src/ui/frmMain.py
@@ -376,6 +376,14 @@ class frmMain(QMainWindow, Ui_frmMain):
         self.actionStdCopy_To.setVisible(False)
         self.actionStdGroup_Edit.setVisible(False)
 
+        if self.model == 'SWMM':
+            if (self.program_settings.value("Geometry/" + "frmMainSWMM_geometry") and
+                    self.program_settings.value("Geometry/" + "frmMainSWMM_state")):
+                self.restoreGeometry(self.program_settings.value("Geometry/" + "frmMainSWMM_geometry",
+                                                                 self.geometry(), type=QtCore.QByteArray))
+                self.restoreState(self.program_settings.value("Geometry/" + "frmMainSWMM_state",
+                                                              self.windowState(), type=QtCore.QByteArray))
+
     def loadBasemap(self):
         pass
 
@@ -2407,6 +2415,11 @@ class frmMain(QMainWindow, Ui_frmMain):
     def action_exit(self):
         if not self.confirm_discard_project():
             return
+
+        if self.model == 'SWMM':
+            self.program_settings.setValue("Geometry/" + "frmMainSWMM_geometry", self.saveGeometry())
+            self.program_settings.setValue("Geometry/" + "frmMainSWMM_state", self.saveState())
+
         del self.program_settings
         del self.project_settings
         try:

--- a/src/ui/frmPreferences.py
+++ b/src/ui/frmPreferences.py
@@ -27,6 +27,13 @@ class frmPreferences(QMainWindow, Ui_frmPreferences):
         self.spnNode.valueChanged.connect(self.spnNode_valueChanged)
         self.spnLink.valueChanged.connect(self.spnLink_valueChanged)
 
+        if (main_form.program_settings.value("Geometry/" + "frmPreferences_geometry") and
+                main_form.program_settings.value("Geometry/" + "frmPreferences_state")):
+            self.restoreGeometry(main_form.program_settings.value("Geometry/" + "frmPreferences_geometry",
+                                                                  self.geometry(), type=QtCore.QByteArray))
+            self.restoreState(main_form.program_settings.value("Geometry/" + "frmPreferences_state",
+                                                               self.windowState(), type=QtCore.QByteArray))
+
     def set_from(self, project):
         if self._main_form.model == "SWMM":
             settings = self._main_form.project_settings
@@ -177,6 +184,10 @@ class frmPreferences(QMainWindow, Ui_frmPreferences):
             self._main_form.update_recent(self._main_form.recent_projects, '')
 
         self._main_form.project_settings.sync_preferences()
+
+        self._main_form.program_settings.setValue("Geometry/" + "frmPreferences_geometry", self.saveGeometry())
+        self._main_form.program_settings.setValue("Geometry/" + "frmPreferences_state", self.saveState())
+
         self.close()
 
     def cmdCancel_Clicked(self):


### PR DESCRIPTION
This PR saves the geometry and state for many SWMM frms.  I don't think it touches any EPANET frms.

I think this closes #302 but there may be something in the comment about defaults that we should open a new issue to track.

@fdumont7 please take a look when you get a change but please don't merge yet.  There are a few more frms I would like to look at on Monday.

Frms that are not modified:
- frmDetails (no OK or cancel button)
- frmProfilePlot (something unknown going on)
- frmQuery (not resizeable)
- frmRunSWMM (appears irrelevant)
