### PR TITLE
Change inlet outlet via property editor

### DIFF
--- a/src/core/project_base.py
+++ b/src/core/project_base.py
@@ -76,7 +76,16 @@ class ProjectBase(object):
                 possible_match = link_group.find_item(link_name)
                 if possible_match:
                     return possible_match
+        return None
 
+    def find_node(self, node_name):
+        if node_name is None or not isinstance(node_name, str) or node_name == '':
+            return None
+        for node_group in self.nodes_groups():
+            if node_group.value and len(node_group.value) > 0:
+                existing_node = node_group.find_item(node_name)
+                if existing_node is not None:
+                    return existing_node
         return None
 
     def all_vertices(self, set_names=False):

--- a/src/ui/SWMM/frmMainSWMM.py
+++ b/src/ui/SWMM/frmMainSWMM.py
@@ -1729,6 +1729,7 @@ class ModelLayersSWMM(ModelLayers):
         ModelLayers.__init__(self, map_widget)
         addCoordinates = self.map_widget.addCoordinates
         addLinks = self.map_widget.addLinks
+        self.create_subcatchment_links = self.map_widget.create_subcatchment_links
         self.junctions = addCoordinates(None, "Junctions")
         self.outfalls = addCoordinates(None, "Outfalls")
         self.dividers = addCoordinates(None, "Dividers")
@@ -1779,125 +1780,9 @@ class ModelLayersSWMM(ModelLayers):
         self.sublinks = addLinks(None, None, "sublinks", QColor('gray'), 1.0)
         self.subcatchments = self.map_widget.addPolygons(project.subcatchments.value, "Subcatchments")
         self.set_lists()
-        self.create_subcatchment_links(project)
+        self.create_subcatchment_links()
         self.create_spatial_index()
         self.map_widget.move_labels_to_anchor_nodes(project, self.labels)
-
-    def create_subcatchment_links(self, project):
-        #create centroids
-        for fs in self.subcatchments.getFeatures():
-            try:
-                self.create_subcatchment_centroid(fs)
-            except:
-                print ("Failed sub centroid: " + fs['name'])
-
-        #create sub links
-        for fs in self.subcatchments.getFeatures():
-            self.create_subcatchment_link(fs)
-
-        pass
-
-    def create_subcatchment_centroid(self, fs):
-        pt = fs.geometry().centroid().asPoint()
-        #ms = self.map_widget.session.project.subcatchments.find_item(fs["name"])
-        ms = None
-        try:
-            ms = self.map_widget.session.project.subcatchments.value[fs['name']]
-        except:
-            ms = None
-        if ms:
-            ms.centroid.x = str(pt.x())
-            ms.centroid.y = str(pt.y())
-        else:
-            return
-
-        # add centroid item
-        c_item = None
-        for obj_type, lyr_name in self.map_widget.session.section_types.items():
-            if lyr_name == "subcentroids":
-                c_item = obj_type()
-                c_item.x = str(pt.x())
-                c_item.y = str(pt.y())
-                break
-        c_item.name = u'subcentroid-' + ms.name #self.map_widget.session.new_item_name(type(c_item))
-        c_section_field_name = self.map_widget.session.section_types[type(c_item)]
-        if not hasattr(self.map_widget.session.project, c_section_field_name):
-            raise Exception("Section not found in project: " + c_section_field_name)
-        c_section = getattr(self.map_widget.session.project, c_section_field_name)
-        centroid_layer = self.map_widget.session.model_layers.layer_by_name(c_section_field_name)
-        if len(c_section.value) == 0 and not isinstance(c_section, list):
-            c_section.value = IndexedList([], ['name'])
-        c_section.value.append(c_item)
-        centroid_layer.startEditing()
-        pf = self.map_widget.point_feature_from_item(ms.centroid)
-        pf.setAttributes([c_item.name, 0.0, fs.id(), ms.name])
-        added_centroid = centroid_layer.dataProvider().addFeatures([pf])
-        if added_centroid[0]:
-            self.subcatchments.startEditing()
-            self.subcatchments.changeAttributeValue(fs.id(), 2, added_centroid[1][0].id())
-            self.subcatchments.changeAttributeValue(fs.id(), 3, c_item.name)
-            self.subcatchments.updateExtents()
-            self.subcatchments.commitChanges()
-            self.subcatchments.triggerRepaint()
-            centroid_layer.updateExtents()
-            centroid_layer.commitChanges()
-            centroid_layer.triggerRepaint()
-
-    def create_subcatchment_link(self, fs):
-        sub_section = getattr(self.project, "subcatchments")
-        ms = sub_section.find_item(fs["name"])
-        if not ms.outlet:
-            return
-        if ms.outlet == 'None':
-            return
-        fc = None
-        fcs = self.map_widget.get_features_by_attribute(self.subcentroids, "sub_modelid", ms.name)
-        if fcs and len(fcs) > 0:
-            fc = fcs[0]
-        else:
-            return
-
-        isSub2Sub = 0 #False
-        # subcent_section = getattr(self.map_widget.session.project, "subcentroids")
-        outlet_sub = None
-        if self.project.subcatchments and self.project.subcatchments.value:
-            outlet_sub = self.project.subcatchments.find_item(ms.outlet)
-            if outlet_sub:
-                fcs = self.map_widget.get_features_by_attribute(self.subcentroids, "sub_modelid", ms.outlet)
-                if fcs and len(fcs) > 0:
-                    outlet_sub = self.project.subcentroids.find_item("subcentroid-" + ms.outlet)
-                    isSub2Sub = 1
-
-        link_item = SubLink()
-        link_item.name = u'sublink-' + ms.name #self.map_widget.session.new_item_name(type(link_item))
-        link_item.inlet_node = fc["name"]
-        if outlet_sub:
-            link_item.outlet_node = outlet_sub.name
-        else:
-            link_item.outlet_node = ms.outlet
-        inlet_sub = ms.centroid
-        f = self.map_widget.line_feature_from_item(link_item,
-                                                   self.map_widget.session.project.all_nodes(),
-                                                   inlet_sub, outlet_sub)
-        added = self.sublinks.dataProvider().addFeatures([f])
-        if added[0]:
-            sublink_section = getattr(self.map_widget.session.project, "sublinks")
-            if len(sublink_section.value) == 0 and not isinstance(sublink_section, list):
-                sublink_section.value = IndexedList([], ['name'])
-            sublink_section.value.append(link_item)
-            # set sublink's attributes
-            self.sublinks.startEditing()
-            # f.setAttributes([str(added[1][0].id()), 0.0, self.item.inlet_node, self.item.outlet_node, self.isSub2Sub])
-            # self.layer.changeAttributeValue(added[1][0].id(), 0, self.item.name)
-            # self.layer.changeAttributeValue(added[1][0].id(), 1, 0.0)
-            self.sublinks.changeAttributeValue(added[1][0].id(), 2, fc["name"])
-            self.sublinks.changeAttributeValue(added[1][0].id(), 3, link_item.outlet_node)
-            self.sublinks.changeAttributeValue(added[1][0].id(), 4, isSub2Sub)
-            self.sublinks.updateExtents()
-            self.sublinks.commitChanges()
-            self.sublinks.triggerRepaint()
-            self.map_widget.canvas.refresh()
-        pass
 
     def find_layer_by_name(self, aname):
         if not aname:

--- a/src/ui/SWMM/frmSubcatchments.py
+++ b/src/ui/SWMM/frmSubcatchments.py
@@ -82,12 +82,12 @@ class frmSubcatchments(frmGenericPropertyEditor):
             combobox.addItem('')
             selected_index = 0
             for value in self.project.all_nodes():
-                combobox.addItem(value.name)
+                combobox.addItem(value.name, value)
                 if edit_these[column].outlet == value.name:
                     selected_index = int(combobox.count()) - 1
             for value in self.project.subcatchments.value:
                 if edit_these[column].name != value.name:
-                    combobox.addItem(value.name)
+                    combobox.addItem(value.name, value)
                 if edit_these[column].outlet == value.name:
                     selected_index = int(combobox.count()) - 1
             combobox.setCurrentIndex(selected_index)

--- a/src/ui/frmGenericPropertyEditor.py
+++ b/src/ui/frmGenericPropertyEditor.py
@@ -57,11 +57,17 @@ class frmGenericPropertyEditor(QMainWindow, Ui_frmGenericPropertyEditor):
 
     def is_name_duplicate(self, irow, icol):
         new_name = self.tblGeneric.item(irow, icol).text()
-        if self.project_section.find_item(new_name):
+        existing_elem = None
+        if self.project_section in self.project.nodes_groups():
+            existing_elem = self.project.find_node(new_name)
+        elif self.project_section in self.project.links_groups():
+            existing_elem = self.project.find_link(new_name)
+        else:
+            existing_elem = self.project_section.find_item(new_name)
+        if existing_elem is not None:
             return True
         else:
             return False
-        pass
 
     def check_change(self, irow, icol):
         ori_value = getattr(self.backend.col_to_item_dict[icol], self.backend.meta[irow].attribute, '')
@@ -70,8 +76,13 @@ class frmGenericPropertyEditor(QMainWindow, Ui_frmGenericPropertyEditor):
             return
         if irow == 0:
             if self.is_name_duplicate(irow, icol):
+                elem_type = type(self.project_section.value[0]).__name__
+                if self.project_section in self.project.nodes_groups():
+                    elem_type = 'Node'
+                elif self.project_section in self.project.links_groups():
+                    elem_type = 'Link'
                 QMessageBox.information(None, self.session.model,
-                                        type(self.project_section.value[0]).__name__ + " '" + new_value + "' already exists.",
+                                        elem_type + " '" + new_value + "' already exists.",
                                         QMessageBox.Ok)
                 self.tblGeneric.cellChanged.disconnect(self.check_change)
                 self.tblGeneric.item(irow, icol).setText(ori_value)

--- a/src/ui/map_tools.py
+++ b/src/ui/map_tools.py
@@ -1963,7 +1963,6 @@ try:
 
         def create_subcatchment_link(self, fs):
             sub_section = getattr(self.session.project, "subcatchments")
-            # sub_section = self.project.subcatchments
             ms = sub_section.find_item(fs["name"])
             if not ms.outlet:
                 return
@@ -2024,14 +2023,15 @@ try:
             req = QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry)
             req.setSubsetOfAttributes([]).setFilterExpression(expr)
             sublinks_lyr = self.session.model_layers.sublinks
-            # for f in sublinks_lyr.getFeatures():
-            #     print(f['name'])
             if sublinks_lyr:
                 it = sublinks_lyr.getFeatures(req)
                 sublinks_lyr.startEditing()
                 sublinks_lyr.deleteFeatures([i.id() for i in it])
                 sublinks_lyr.commitChanges()
                 sublinks_lyr.triggerRepaint()
+            sublink_model = self.session.project.sublinks.find_item('sublink-subcentroid-' + subcatchment.name)
+            if sublink_model is not None:
+                self.session.project.sublinks.value.remove(sublink_model)
             layer = self.session.model_layers.subcatchments
             features = self.get_features_by_attribute(layer, "name", subcatchment.name)
             for fs in features:

--- a/src/ui/map_tools.py
+++ b/src/ui/map_tools.py
@@ -469,6 +469,13 @@ try:
             for feature in layer.getFeatures(QgsFeatureRequest(QgsExpression('"name"=' + "'" + feature_name + "'"))):
                 return feature
 
+        def find_feature_by_attribute(self, layer, attribute, values):
+            if layer and values and len(values) > 0:
+                expr = "\"" + attribute + "\"" + " IN ('{}')".format("','".join(values))
+                req = QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry)
+                req.setSubsetOfAttributes([]).setFilterExpression(expr)
+                return layer.getFeatures(req)
+
         def setAddObjectMode(self, action_obj, layer_name, tool_type):
             """Start interactively adding points to point layer layer_name using tool button action_obj"""
             if self.addObjectTool:
@@ -1988,9 +1995,16 @@ try:
                     if fcs and len(fcs) > 0:
                         outlet_sub = model_subcentroids.find_item("subcentroid-" + ms.outlet)
                         isSub2Sub = 1
+            inlet_node = None
+            if model_subcentroids and model_subcentroids.value:
+                try:
+                    inlet_node = model_subcentroids.value[u'subcentroid-' + ms.name]
+                except KeyError as ke:
+                    inlet_node = None
 
             link_item = SubLink()
-            link_item.name = u'sublink-' + ms.name  # self.map_widget.session.new_item_name(type(link_item))
+            # link_item.name = u'sublink-' + ms.name  # self.map_widget.session.new_item_name(type(link_item))
+            link_item.name = u'sublink-' + inlet_node.name
             link_item.inlet_node = fc["name"]
             if outlet_sub:
                 link_item.outlet_node = outlet_sub.name
@@ -2019,23 +2033,63 @@ try:
             pass
 
         def change_subcatchment_link(self, subcatchment, new_endpoint):
-            expr = "\"inlet\" IN ('{}')".format("','".join(['subcentroid-' + subcatchment.name]))
-            req = QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry)
-            req.setSubsetOfAttributes([]).setFilterExpression(expr)
             sublinks_lyr = self.session.model_layers.sublinks
             if sublinks_lyr:
-                it = sublinks_lyr.getFeatures(req)
+                it = self.find_feature_by_attribute(sublinks_lyr, 'inlet', ['subcentroid-' + subcatchment.name])
                 sublinks_lyr.startEditing()
                 sublinks_lyr.deleteFeatures([i.id() for i in it])
                 sublinks_lyr.commitChanges()
                 sublinks_lyr.triggerRepaint()
+            subcent_lyr = self.session.model_layers.subcentroids
+            if subcent_lyr:
+                it = self.find_feature_by_attribute(subcent_lyr, 'name', ['subcentroid-' + subcatchment.name])
+                subcent_lyr.startEditing()
+                subcent_lyr.deleteFeatures([i.id() for i in it])
+                subcent_lyr.commitChanges()
+                subcent_lyr.triggerRepaint()
             sublink_model = self.session.project.sublinks.find_item('sublink-subcentroid-' + subcatchment.name)
+            subcent_model = self.session.project.subcentroids.find_item('subcentroid-' + subcatchment.name)
             if sublink_model is not None:
                 self.session.project.sublinks.value.remove(sublink_model)
+            if subcent_model is not None:
+                self.session.project.subcentroids.value.remove(subcent_model)
             layer = self.session.model_layers.subcatchments
             features = self.get_features_by_attribute(layer, "name", subcatchment.name)
             for fs in features:
+                self.create_subcatchment_centroid(fs)
                 self.create_subcatchment_link(fs)
+            self.session.model_layers.subcentroids.dataProvider().createSpatialIndex()
+            self.session.model_layers.sublinks.dataProvider().createSpatialIndex()
+            pass
+
+        def change_link(self, link, attribute):
+            link_section = None
+            for i in range(0, len(self.session.project.links_groups())):
+                link_section = self.session.project.links_groups()[i].value
+                if link in link_section:
+                    break
+            if link_section:
+                new_node_name = getattr(link, attribute)
+                new_node = self.session.project.find_node(new_node_name)
+                if new_node_name and new_node:
+                    layer = self.session.model_layers.find_layer_by_name(type(link).__name__)
+                    it = self.find_feature_by_attribute(layer, 'name', [link.name])
+                    for feature in it:
+                        link_points = [QgsPoint(v.x(), v.y()) for v in feature.geometry().vertices()]
+                        vfi = -1
+                        if attribute.startswith('inlet'):
+                            link_points[0] = QgsPoint(new_node.x, new_node.y)
+                            vfi = feature.fieldNameIndex('inlet')
+                        elif attribute.startswith('outlet'):
+                            link_points[-1] = QgsPoint(new_node.x, new_node.y)
+                            vfi = feature.fieldNameIndex('outlet')
+                        layer.startEditing()
+                        layer.changeGeometry(feature.id(), QgsGeometry.fromPolyline(link_points))
+                        layer.commitChanges()
+                        layer.dataProvider().changeAttributeValues({feature.id(): {vfi: str(new_node_name)}})
+                        layer.updateExtents()
+                        layer.triggerRepaint()
+                pass
 
         def create_composition(self, layer_list, extent):
             # New code for versions 2.4 and above

--- a/src/ui/map_tools.py
+++ b/src/ui/map_tools.py
@@ -23,6 +23,8 @@ try:
     from enum import Enum
     from .map_edit import EditTool
     from ui.model_utility import ParseData
+    from core.indexed_list import IndexedList
+    from core.swmm.hydraulics.link import SubLink
 
 
     class EmbedMap(QWidget):
@@ -1896,6 +1898,144 @@ try:
                             total_selected = total_selected + len(selected_ids)
                             lyr.triggerRepaint()
             return total_selected
+
+        def create_subcatchment_links(self):
+            # create centroids
+            subcatchments_lyr = self.session.model_layers.subcatchments
+            for fs in subcatchments_lyr.getFeatures():
+                try:
+                    self.create_subcatchment_centroid(fs)
+                except:
+                    print("Failed sub centroid: " + fs['name'])
+
+            # create sub links
+            for fs in subcatchments_lyr.getFeatures():
+                self.create_subcatchment_link(fs)
+
+            pass
+
+        def create_subcatchment_centroid(self, fs):
+            pt = fs.geometry().centroid().asPoint()
+            # ms = self.map_widget.session.project.subcatchments.find_item(fs["name"])
+            ms = None
+            try:
+                ms = self.session.project.subcatchments.value[fs['name']]
+            except:
+                ms = None
+            if ms:
+                ms.centroid.x = str(pt.x())
+                ms.centroid.y = str(pt.y())
+            else:
+                return
+
+            # add centroid item
+            c_item = None
+            for obj_type, lyr_name in self.session.section_types.items():
+                if lyr_name == "subcentroids":
+                    c_item = obj_type()
+                    c_item.x = str(pt.x())
+                    c_item.y = str(pt.y())
+                    break
+            c_item.name = u'subcentroid-' + ms.name  # self.map_widget.session.new_item_name(type(c_item))
+            c_section_field_name = self.session.section_types[type(c_item)]
+            if not hasattr(self.session.project, c_section_field_name):
+                raise Exception("Section not found in project: " + c_section_field_name)
+            c_section = getattr(self.session.project, c_section_field_name)
+            centroid_layer = self.session.model_layers.layer_by_name(c_section_field_name)
+            if len(c_section.value) == 0 and not isinstance(c_section, list):
+                c_section.value = IndexedList([], ['name'])
+            c_section.value.append(c_item)
+            centroid_layer.startEditing()
+            pf = self.point_feature_from_item(ms.centroid)
+            pf.setAttributes([c_item.name, 0.0, fs.id(), ms.name])
+            added_centroid = centroid_layer.dataProvider().addFeatures([pf])
+            subcatchments_lyr = self.session.model_layers.subcatchments
+            if added_centroid[0]:
+                subcatchments_lyr.startEditing()
+                subcatchments_lyr.changeAttributeValue(fs.id(), 2, added_centroid[1][0].id())
+                subcatchments_lyr.changeAttributeValue(fs.id(), 3, c_item.name)
+                subcatchments_lyr.updateExtents()
+                subcatchments_lyr.commitChanges()
+                subcatchments_lyr.triggerRepaint()
+                centroid_layer.updateExtents()
+                centroid_layer.commitChanges()
+                centroid_layer.triggerRepaint()
+
+        def create_subcatchment_link(self, fs):
+            sub_section = getattr(self.session.project, "subcatchments")
+            # sub_section = self.project.subcatchments
+            ms = sub_section.find_item(fs["name"])
+            if not ms.outlet:
+                return
+            if ms.outlet == 'None':
+                return
+            fc = None
+            fcs = self.get_features_by_attribute(self.session.model_layers.subcentroids, "sub_modelid", ms.name)
+            if fcs and len(fcs) > 0:
+                fc = fcs[0]
+            else:
+                return
+
+            isSub2Sub = 0  # False
+            # subcent_section = getattr(self.map_widget.session.project, "subcentroids")
+            outlet_sub = None
+            model_subcatchments = self.session.project.subcatchments
+            model_subcentroids = self.session.project.subcentroids
+            layer_subcentroids = self.session.model_layers.subcentroids
+            if model_subcatchments and model_subcatchments.value:
+                outlet_sub = model_subcatchments.find_item(ms.outlet)
+                if outlet_sub:
+                    fcs = self.get_features_by_attribute(layer_subcentroids, "sub_modelid", ms.outlet)
+                    if fcs and len(fcs) > 0:
+                        outlet_sub = model_subcentroids.find_item("subcentroid-" + ms.outlet)
+                        isSub2Sub = 1
+
+            link_item = SubLink()
+            link_item.name = u'sublink-' + ms.name  # self.map_widget.session.new_item_name(type(link_item))
+            link_item.inlet_node = fc["name"]
+            if outlet_sub:
+                link_item.outlet_node = outlet_sub.name
+            else:
+                link_item.outlet_node = ms.outlet
+            inlet_sub = ms.centroid
+            f = self.line_feature_from_item(link_item,
+                                            self.session.project.all_nodes(),
+                                            inlet_sub, outlet_sub)
+            sublinks_lyr = self.session.model_layers.sublinks
+            added = sublinks_lyr.dataProvider().addFeatures([f])
+            if added[0]:
+                sublink_section = getattr(self.session.project, "sublinks")
+                if len(sublink_section.value) == 0 and not isinstance(sublink_section, list):
+                    sublink_section.value = IndexedList([], ['name'])
+                sublink_section.value.append(link_item)
+                # set sublink's attributes
+                sublinks_lyr.startEditing()
+                sublinks_lyr.changeAttributeValue(added[1][0].id(), 2, fc["name"])
+                sublinks_lyr.changeAttributeValue(added[1][0].id(), 3, link_item.outlet_node)
+                sublinks_lyr.changeAttributeValue(added[1][0].id(), 4, isSub2Sub)
+                sublinks_lyr.updateExtents()
+                sublinks_lyr.commitChanges()
+                sublinks_lyr.triggerRepaint()
+                self.canvas.refresh()
+            pass
+
+        def change_subcatchment_link(self, subcatchment, new_endpoint):
+            expr = "\"inlet\" IN ('{}')".format("','".join(['subcentroid-' + subcatchment.name]))
+            req = QgsFeatureRequest().setFlags(QgsFeatureRequest.NoGeometry)
+            req.setSubsetOfAttributes([]).setFilterExpression(expr)
+            sublinks_lyr = self.session.model_layers.sublinks
+            # for f in sublinks_lyr.getFeatures():
+            #     print(f['name'])
+            if sublinks_lyr:
+                it = sublinks_lyr.getFeatures(req)
+                sublinks_lyr.startEditing()
+                sublinks_lyr.deleteFeatures([i.id() for i in it])
+                sublinks_lyr.commitChanges()
+                sublinks_lyr.triggerRepaint()
+            layer = self.session.model_layers.subcatchments
+            features = self.get_features_by_attribute(layer, "name", subcatchment.name)
+            for fs in features:
+                self.create_subcatchment_link(fs)
 
         def create_composition(self, layer_list, extent):
             # New code for versions 2.4 and above

--- a/src/ui/property_editor_backend.py
+++ b/src/ui/property_editor_backend.py
@@ -114,6 +114,9 @@ class PropertyEditorBackend:
                                                     new_endpoint = widget.itemData(widget.currentIndex())
                                                     # the changed model element is: edit_this
                                                     self._main_form.map_widget.change_subcatchment_link(edit_this, new_endpoint)
+                                            elif meta_item.attribute == 'outlet_node' or meta_item.attribute == "inlet_node":
+                                                self._main_form.map_widget.change_link(edit_this, meta_item.attribute)
+
                                     except Exception as ex:
                                         print("Could not set " + str(meta_item.label) + " to " + str(new_value))
             column += 1

--- a/src/ui/property_editor_backend.py
+++ b/src/ui/property_editor_backend.py
@@ -108,6 +108,12 @@ class PropertyEditorBackend:
                                             self._main_form.mark_project_as_unsaved()
                                             if meta_item.attribute == "name":
                                                 edited_names.append((old_value, edit_this))
+                                            if meta_item.attribute == 'outlet' or meta_item.attribute == 'inlet':
+                                                if isinstance(edit_this, \
+                                                              type(self._main_form.project.subcatchments.value[0])):
+                                                    new_endpoint = widget.itemData(widget.currentIndex())
+                                                    # the changed model element is: edit_this
+                                                    self._main_form.map_widget.change_subcatchment_link(edit_this, new_endpoint)
                                     except Exception as ex:
                                         print("Could not set " + str(meta_item.label) + " to " + str(new_value))
             column += 1


### PR DESCRIPTION
This PR implemented the new feature request #347 that allows changing of model object's inlet/outlet from inside its property editor, e.g. change a sub-catchment's outlet from its property editor